### PR TITLE
fix: add reputationId to SorobanIdentityConfig, remove inline type ex…

### DIFF
--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -19,9 +19,9 @@ export interface ReputationRecord {
 export class ReputationClient {
   private server: SorobanRpc.Server;
   private contract: Contract;
-  private config: SorobanIdentityConfig & { reputationId: string };
+  private config: SorobanIdentityConfig;
 
-  constructor(config: SorobanIdentityConfig & { reputationId: string }) {
+  constructor(config: SorobanIdentityConfig) {
     this.config = config;
     this.server = new SorobanRpc.Server(config.rpcUrl);
     this.contract = new Contract(config.reputationId);

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -26,4 +26,5 @@ export interface SorobanIdentityConfig {
   networkPassphrase: string;
   identityRegistryId: string;
   credentialManagerId: string;
+  reputationId: string;
 }


### PR DESCRIPTION
**fix: add `reputationId` to `SorobanIdentityConfig`**

## Problem

`SorobanIdentityConfig` was missing `reputationId`, forcing `ReputationClient` to extend the type inline everywhere it was instantiated:

```ts
config: SorobanIdentityConfig & { reputationId: string }
```

This was inconsistent with how `IdentityClient` and `CredentialClient` consume the config — both use `SorobanIdentityConfig` directly with no extensions.

## Changes

- Added `reputationId: string` to `SorobanIdentityConfig` in `sdk/src/types.ts`
- Removed the `& { reputationId: string }` intersection from `ReputationClient` in `sdk/src/reputation.ts` — both the field type and constructor param now use `SorobanIdentityConfig` directly

## Result

All three clients now share a single unified config shape. Callers pass one config object to any client without workarounds.

```ts
const config: SorobanIdentityConfig = {
  rpcUrl: "...",
  networkPassphrase: "...",
  identityRegistryId: "...",
  credentialManagerId: "...",
  reputationId: "...",
};

new IdentityClient(config);
new CredentialClient(config);
new ReputationClient(config); // no more inline extension
```

Close #2 