### PR TITLE
Fix/export testnet mainnet config

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,14 +142,29 @@ cd sdk && npm install
 
 Usage:
 ```ts
-import { IdentityClient, CredentialClient, ReputationClient, TESTNET_CONFIG } from "@soroban-identity/sdk";
+import {
+  IdentityClient,
+  CredentialClient,
+  ReputationClient,
+  TESTNET_CONFIG,
+  MAINNET_CONFIG,
+} from "@soroban-identity/sdk";
 
+// Testnet — spread and override the three contract IDs after deployment
 const config = {
   ...TESTNET_CONFIG,
   identityRegistryId: "YOUR_REGISTRY_CONTRACT_ID",
   credentialManagerId: "YOUR_CREDENTIAL_CONTRACT_ID",
   reputationId: "YOUR_REPUTATION_CONTRACT_ID",
 };
+
+// Mainnet — same pattern, different base config
+// const config = {
+//   ...MAINNET_CONFIG,
+//   identityRegistryId: "YOUR_REGISTRY_CONTRACT_ID",
+//   credentialManagerId: "YOUR_CREDENTIAL_CONTRACT_ID",
+//   reputationId: "YOUR_REPUTATION_CONTRACT_ID",
+// };
 
 // Resolve a DID
 const identity = new IdentityClient(config);

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,10 +9,20 @@ export type {
 } from "./types";
 export type { ReputationRecord } from "./reputation";
 
-// Testnet defaults
-export const TESTNET_CONFIG = {
+// Testnet defaults — fill contract IDs after deployment
+export const TESTNET_CONFIG: SorobanIdentityConfig = {
   rpcUrl: "https://soroban-testnet.stellar.org",
   networkPassphrase: "Test SDF Network ; September 2015",
-  identityRegistryId: "", // fill after deployment
-  credentialManagerId: "", // fill after deployment
+  identityRegistryId: "",
+  credentialManagerId: "",
+  reputationId: "",
+};
+
+// Mainnet defaults — fill contract IDs after deployment
+export const MAINNET_CONFIG: SorobanIdentityConfig = {
+  rpcUrl: "https://soroban-mainnet.stellar.org",
+  networkPassphrase: "Public Global Stellar Network ; September 2015",
+  identityRegistryId: "",
+  credentialManagerId: "",
+  reputationId: "",
 };

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -19,9 +19,9 @@ export interface ReputationRecord {
 export class ReputationClient {
   private server: SorobanRpc.Server;
   private contract: Contract;
-  private config: SorobanIdentityConfig & { reputationId: string };
+  private config: SorobanIdentityConfig;
 
-  constructor(config: SorobanIdentityConfig & { reputationId: string }) {
+  constructor(config: SorobanIdentityConfig) {
     this.config = config;
     this.server = new SorobanRpc.Server(config.rpcUrl);
     this.contract = new Contract(config.reputationId);

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -26,4 +26,5 @@ export interface SorobanIdentityConfig {
   networkPassphrase: string;
   identityRegistryId: string;
   credentialManagerId: string;
+  reputationId: string;
 }


### PR DESCRIPTION
**fix: export `TESTNET_CONFIG` and `MAINNET_CONFIG` from SDK**

## Problem

The README showed `TESTNET_CONFIG` being imported from `@soroban-identity/sdk`, but it was never exported with `reputationId` and `MAINNET_CONFIG` didn't exist at all. Anyone following the docs would hit an immediate import error or end up with a config object that didn't satisfy `SorobanIdentityConfig`.

## Changes

- Added `reputationId` to `TESTNET_CONFIG` so it fully satisfies `SorobanIdentityConfig`
- Typed both constants as `SorobanIdentityConfig` so any future interface changes are caught at compile time
- Added `MAINNET_CONFIG` with the correct mainnet RPC URL and network passphrase
- Updated README usage example to import and document both constants

## Result

```ts
import {
  IdentityClient,
  CredentialClient,
  ReputationClient,
  TESTNET_CONFIG,
  MAINNET_CONFIG,
} from "@soroban-identity/sdk";

const config = {
  ...TESTNET_CONFIG, // or MAINNET_CONFIG
  identityRegistryId: "YOUR_REGISTRY_CONTRACT_ID",
  credentialManagerId: "YOUR_CREDENTIAL_CONTRACT_ID",
  reputationId: "YOUR_REPUTATION_CONTRACT_ID",
};
```

The README example now works without modification.

Close #3 