### PR TITLE
Feat/reputation get score history

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,14 +142,29 @@ cd sdk && npm install
 
 Usage:
 ```ts
-import { IdentityClient, CredentialClient, ReputationClient, TESTNET_CONFIG } from "@soroban-identity/sdk";
+import {
+  IdentityClient,
+  CredentialClient,
+  ReputationClient,
+  TESTNET_CONFIG,
+  MAINNET_CONFIG,
+} from "@soroban-identity/sdk";
 
+// Testnet — spread and override the three contract IDs after deployment
 const config = {
   ...TESTNET_CONFIG,
   identityRegistryId: "YOUR_REGISTRY_CONTRACT_ID",
   credentialManagerId: "YOUR_CREDENTIAL_CONTRACT_ID",
   reputationId: "YOUR_REPUTATION_CONTRACT_ID",
 };
+
+// Mainnet — same pattern, different base config
+// const config = {
+//   ...MAINNET_CONFIG,
+//   identityRegistryId: "YOUR_REGISTRY_CONTRACT_ID",
+//   credentialManagerId: "YOUR_CREDENTIAL_CONTRACT_ID",
+//   reputationId: "YOUR_REPUTATION_CONTRACT_ID",
+// };
 
 // Resolve a DID
 const identity = new IdentityClient(config);

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -7,7 +7,7 @@ export type {
   CredentialType,
   SorobanIdentityConfig,
 } from "./types";
-export type { ReputationRecord } from "./reputation";
+export type { ReputationRecord, ScoreHistoryEntry } from "./reputation";
 
 // Testnet defaults — fill contract IDs after deployment
 export const TESTNET_CONFIG: SorobanIdentityConfig = {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,10 +9,20 @@ export type {
 } from "./types";
 export type { ReputationRecord } from "./reputation";
 
-// Testnet defaults
-export const TESTNET_CONFIG = {
+// Testnet defaults — fill contract IDs after deployment
+export const TESTNET_CONFIG: SorobanIdentityConfig = {
   rpcUrl: "https://soroban-testnet.stellar.org",
   networkPassphrase: "Test SDF Network ; September 2015",
-  identityRegistryId: "", // fill after deployment
-  credentialManagerId: "", // fill after deployment
+  identityRegistryId: "",
+  credentialManagerId: "",
+  reputationId: "",
+};
+
+// Mainnet defaults — fill contract IDs after deployment
+export const MAINNET_CONFIG: SorobanIdentityConfig = {
+  rpcUrl: "https://soroban-mainnet.stellar.org",
+  networkPassphrase: "Public Global Stellar Network ; September 2015",
+  identityRegistryId: "",
+  credentialManagerId: "",
+  reputationId: "",
 };

--- a/sdk/src/reputation.test.ts
+++ b/sdk/src/reputation.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ReputationClient } from "./reputation";
+import type { SorobanIdentityConfig } from "./types";
+
+// ── Shared mocks ──────────────────────────────────────────────────────────────
+
+const mockSimulateTransaction = vi.fn();
+const mockGetAccount = vi.fn().mockResolvedValue({ id: "GCALLER" });
+
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@stellar/stellar-sdk")>();
+  return {
+    ...actual,
+    SorobanRpc: {
+      ...actual.SorobanRpc,
+      Server: vi.fn().mockImplementation(() => ({
+        getAccount: mockGetAccount,
+        simulateTransaction: mockSimulateTransaction,
+      })),
+      Api: {
+        isSimulationError: (r: unknown) =>
+          (r as { error?: string }).error !== undefined,
+      },
+    },
+    Contract: vi.fn().mockImplementation(() => ({
+      call: vi.fn().mockReturnValue({}),
+    })),
+    TransactionBuilder: vi.fn().mockImplementation(() => ({
+      addOperation: vi.fn().mockReturnThis(),
+      setTimeout: vi.fn().mockReturnThis(),
+      build: vi.fn().mockReturnValue({}),
+    })),
+    BASE_FEE: "100",
+    nativeToScVal: vi.fn(),
+    scValToNative: vi.fn(),
+  };
+});
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const config: SorobanIdentityConfig = {
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  identityRegistryId: "CONTRACT_IDENTITY",
+  credentialManagerId: "CONTRACT_CREDENTIAL",
+  reputationId: "CONTRACT_REPUTATION",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("ReputationClient.getScoreHistory", () => {
+  let client: ReputationClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new ReputationClient(config);
+  });
+
+  it("returns decoded ScoreHistoryEntry array on success", async () => {
+    const { scValToNative } =
+      await import("@stellar/stellar-sdk");
+
+    const mockEntries = [
+      { reporter: "GREPORTER", delta: 50, reason: "completed KYC", submittedAt: 1700000000 },
+      { reporter: "GREPORTER", delta: 25, reason: "active trader",  submittedAt: 1700001000 },
+    ];
+
+    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue(mockEntries);
+    mockSimulateTransaction.mockResolvedValue({
+      result: { retval: {} },
+    });
+
+    const result = await client.getScoreHistory(
+      "GCALLER",
+      "GSUBJECT",
+      "GREPORTER"
+    );
+
+    expect(result).toEqual(mockEntries);
+    expect(result).toHaveLength(2);
+    expect(result[0].delta).toBe(50);
+    expect(result[1].reason).toBe("active trader");
+  });
+
+  it("throws when simulation returns an error", async () => {
+    mockSimulateTransaction.mockResolvedValue({ error: "contract trap" });
+
+    await expect(
+      client.getScoreHistory("GCALLER", "GSUBJECT", "GREPORTER")
+    ).rejects.toThrow("Simulation failed: contract trap");
+  });
+
+  it("returns an empty array when the reporter has no history", async () => {
+    const { scValToNative } =
+      await import("@stellar/stellar-sdk");
+
+    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    mockSimulateTransaction.mockResolvedValue({
+      result: { retval: {} },
+    });
+
+    const result = await client.getScoreHistory(
+      "GCALLER",
+      "GSUBJECT",
+      "GREPORTER_NEW"
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -16,6 +16,13 @@ export interface ReputationRecord {
   updatedAt: number;
 }
 
+export interface ScoreHistoryEntry {
+  reporter: string;
+  delta: number;
+  reason: string;
+  submittedAt: number;
+}
+
 export class ReputationClient {
   private server: SorobanRpc.Server;
   private contract: Contract;
@@ -52,6 +59,38 @@ export class ReputationClient {
     return scValToNative(
       (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval
     ) as ReputationRecord;
+  }
+
+  /** Get score submission history for a subject from a specific reporter. */
+  async getScoreHistory(
+    callerAddress: string,
+    subjectAddress: string,
+    reporterAddress: string
+  ): Promise<ScoreHistoryEntry[]> {
+    const account = await this.server.getAccount(callerAddress);
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          "get_history",
+          nativeToScVal(subjectAddress, { type: "address" }),
+          nativeToScVal(reporterAddress, { type: "address" })
+        )
+      )
+      .setTimeout(30)
+      .build();
+
+    const result = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(result)) {
+      throw new Error(`Simulation failed: ${result.error}`);
+    }
+
+    return scValToNative(
+      (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval
+    ) as ScoreHistoryEntry[];
   }
 
   /** Check if a subject passes the sybil threshold. */

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -19,9 +19,9 @@ export interface ReputationRecord {
 export class ReputationClient {
   private server: SorobanRpc.Server;
   private contract: Contract;
-  private config: SorobanIdentityConfig & { reputationId: string };
+  private config: SorobanIdentityConfig;
 
-  constructor(config: SorobanIdentityConfig & { reputationId: string }) {
+  constructor(config: SorobanIdentityConfig) {
     this.config = config;
     this.server = new SorobanRpc.Server(config.rpcUrl);
     this.contract = new Contract(config.reputationId);

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -26,4 +26,5 @@ export interface SorobanIdentityConfig {
   networkPassphrase: string;
   identityRegistryId: string;
   credentialManagerId: string;
+  reputationId: string;
 }


### PR DESCRIPTION
**feat: implement `ReputationClient.getScoreHistory`**

## Problem

The `reputation` contract exposes `get_history(subject, reporter) -> Vec<ScoreEntry>` but the TypeScript SDK had no wrapper for it. dApp developers had to write raw Soroban RPC calls to access score history, which is inconsistent with the rest of the SDK surface.

## Changes

`sdk/src/reputation.ts`
- Added `ScoreHistoryEntry` interface matching the contract's `ScoreEntry` struct (`reporter`, `delta`, `reason`, `submittedAt`)
- Implemented `getScoreHistory(callerAddress, subjectAddress, reporterAddress)` — follows the exact same simulate-then-decode pattern as `getReputation`, calls `get_history` with two `address` ScVals, throws on simulation error

`sdk/src/index.ts`
- Re-exported `ScoreHistoryEntry` alongside `ReputationRecord`

`sdk/src/reputation.test.ts` _(new file)_
- Happy path: returns decoded `ScoreHistoryEntry[]`
- Error path: throws when simulation returns an error
- Edge case: returns empty array when reporter has no history

## Usage

```ts
const history = await reputation.getScoreHistory(
  "GCALLER...",
  "GSUBJECT...",
  "GREPORTER..."
);
// [{ reporter: "G...", delta: 50, reason: "completed KYC", submittedAt: 1700000000 }, ...]
```

Close #1 