### PR TITLE
feat: add limit/offset pagination to get_history contract and SDK

### DIFF
--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -147,16 +147,34 @@ impl Reputation {
     }
 
     /// Get score history submitted by a specific reporter for a subject.
+    ///
+    /// `offset` — number of entries to skip (0-based).
+    /// `limit`  — maximum number of entries to return (capped at 100).
     pub fn get_history(
         env: Env,
         subject: Address,
         reporter: Address,
+        offset: u32,
+        limit: u32,
     ) -> Vec<ScoreEntry> {
         let key = Self::history_key(&env, &subject, &reporter);
-        env.storage()
+        let all: Vec<ScoreEntry> = env
+            .storage()
             .persistent()
             .get(&key)
-            .unwrap_or_else(|| Vec::new(&env))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let cap: u32 = 100;
+        let effective_limit = if limit == 0 || limit > cap { cap } else { limit };
+        let len = all.len();
+        let start = offset.min(len);
+        let end = (start + effective_limit).min(len);
+
+        let mut page = Vec::new(&env);
+        for i in start..end {
+            page.push_back(all.get(i).unwrap());
+        }
+        page
     }
 
     /// Simple anti-sybil check: returns true if score >= threshold AND
@@ -240,6 +258,48 @@ mod tests {
         let rec = client.get_reputation(&subject);
         assert_eq!(rec.score, 75);
         assert_eq!(rec.reporter_count, 1); // same reporter
+    }
+
+    #[test]
+    fn test_get_history_pagination() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, Reputation);
+        let client = ReputationClient::new(&env, &contract_id);
+
+        let admin    = Address::generate(&env);
+        let reporter = Address::generate(&env);
+        let subject  = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.add_reporter(&reporter);
+
+        // Submit 5 entries
+        for i in 0..5_i64 {
+            let reason = String::from_str(&env, "reason");
+            client.submit_score(&reporter, &subject, &i, &reason);
+        }
+
+        // First page: offset=0, limit=2 → entries 0,1
+        let page1 = client.get_history(&subject, &reporter, &0, &2);
+        assert_eq!(page1.len(), 2);
+        assert_eq!(page1.get(0).unwrap().delta, 0);
+        assert_eq!(page1.get(1).unwrap().delta, 1);
+
+        // Second page: offset=2, limit=2 → entries 2,3
+        let page2 = client.get_history(&subject, &reporter, &2, &2);
+        assert_eq!(page2.len(), 2);
+        assert_eq!(page2.get(0).unwrap().delta, 2);
+
+        // Last page: offset=4, limit=10 → only entry 4 remains
+        let page3 = client.get_history(&subject, &reporter, &4, &10);
+        assert_eq!(page3.len(), 1);
+        assert_eq!(page3.get(0).unwrap().delta, 4);
+
+        // Offset beyond length → empty
+        let empty = client.get_history(&subject, &reporter, &99, &10);
+        assert_eq!(empty.len(), 0);
     }
 
     #[test]

--- a/sdk/src/reputation.test.ts
+++ b/sdk/src/reputation.test.ts
@@ -57,8 +57,7 @@ describe("ReputationClient.getScoreHistory", () => {
   });
 
   it("returns decoded ScoreHistoryEntry array on success", async () => {
-    const { scValToNative } =
-      await import("@stellar/stellar-sdk");
+    const { scValToNative } = await import("@stellar/stellar-sdk");
 
     const mockEntries = [
       { reporter: "GREPORTER", delta: 50, reason: "completed KYC", submittedAt: 1700000000 },
@@ -66,20 +65,49 @@ describe("ReputationClient.getScoreHistory", () => {
     ];
 
     (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue(mockEntries);
-    mockSimulateTransaction.mockResolvedValue({
-      result: { retval: {} },
-    });
+    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
 
-    const result = await client.getScoreHistory(
-      "GCALLER",
-      "GSUBJECT",
-      "GREPORTER"
-    );
+    const result = await client.getScoreHistory("GCALLER", "GSUBJECT", "GREPORTER");
 
     expect(result).toEqual(mockEntries);
     expect(result).toHaveLength(2);
     expect(result[0].delta).toBe(50);
     expect(result[1].reason).toBe("active trader");
+  });
+
+  it("uses default limit=20 and offset=0 when not provided", async () => {
+    const { nativeToScVal, scValToNative } = await import("@stellar/stellar-sdk");
+
+    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+
+    await client.getScoreHistory("GCALLER", "GSUBJECT", "GREPORTER");
+
+    expect(nativeToScVal).toHaveBeenCalledWith(0,  { type: "u32" }); // offset
+    expect(nativeToScVal).toHaveBeenCalledWith(20, { type: "u32" }); // limit
+  });
+
+  it("forwards custom limit and offset to the contract call", async () => {
+    const { nativeToScVal, scValToNative } = await import("@stellar/stellar-sdk");
+
+    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+
+    await client.getScoreHistory("GCALLER", "GSUBJECT", "GREPORTER", 40, 10);
+
+    expect(nativeToScVal).toHaveBeenCalledWith(40, { type: "u32" }); // offset
+    expect(nativeToScVal).toHaveBeenCalledWith(10, { type: "u32" }); // limit
+  });
+
+  it("returns an empty array for a reporter with no history", async () => {
+    const { scValToNative } = await import("@stellar/stellar-sdk");
+
+    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+
+    const result = await client.getScoreHistory("GCALLER", "GSUBJECT", "GREPORTER_NEW");
+
+    expect(result).toEqual([]);
   });
 
   it("throws when simulation returns an error", async () => {
@@ -88,23 +116,5 @@ describe("ReputationClient.getScoreHistory", () => {
     await expect(
       client.getScoreHistory("GCALLER", "GSUBJECT", "GREPORTER")
     ).rejects.toThrow("Simulation failed: contract trap");
-  });
-
-  it("returns an empty array when the reporter has no history", async () => {
-    const { scValToNative } =
-      await import("@stellar/stellar-sdk");
-
-    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue([]);
-    mockSimulateTransaction.mockResolvedValue({
-      result: { retval: {} },
-    });
-
-    const result = await client.getScoreHistory(
-      "GCALLER",
-      "GSUBJECT",
-      "GREPORTER_NEW"
-    );
-
-    expect(result).toEqual([]);
   });
 });

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -61,11 +61,21 @@ export class ReputationClient {
     ) as ReputationRecord;
   }
 
-  /** Get score submission history for a subject from a specific reporter. */
+  /**
+   * Get score submission history for a subject from a specific reporter.
+   *
+   * @param callerAddress   - Stellar address used to build the transaction.
+   * @param subjectAddress  - The subject whose history is being queried.
+   * @param reporterAddress - The reporter whose submissions to retrieve.
+   * @param offset          - Number of entries to skip (default: 0).
+   * @param limit           - Maximum entries to return (default: 20, contract cap: 100).
+   */
   async getScoreHistory(
     callerAddress: string,
     subjectAddress: string,
-    reporterAddress: string
+    reporterAddress: string,
+    offset = 0,
+    limit = 20
   ): Promise<ScoreHistoryEntry[]> {
     const account = await this.server.getAccount(callerAddress);
 
@@ -77,7 +87,9 @@ export class ReputationClient {
         this.contract.call(
           "get_history",
           nativeToScVal(subjectAddress, { type: "address" }),
-          nativeToScVal(reporterAddress, { type: "address" })
+          nativeToScVal(reporterAddress, { type: "address" }),
+          nativeToScVal(offset, { type: "u32" }),
+          nativeToScVal(limit, { type: "u32" })
         )
       )
       .setTimeout(30)


### PR DESCRIPTION
Close #34 

**Title:** `feat: add limit/offset pagination to get_history contract and SDK`

**Body:**

```
## Summary

Adds server-side pagination to the `get_history` contract function and exposes
`limit`/`offset` params in the SDK's `getScoreHistory` method.

## Problem

`get_history` returned all score entries at once with no pagination, making it
slow and expensive for subjects with long histories.

## Changes

### Contract (`contracts/reputation/src/lib.rs`)
- `get_history` now accepts `offset: u32` and `limit: u32`
- Slices the entry vec server-side — only the requested page is returned
- Hard cap of 100 entries per call; `limit=0` falls back to the cap
- Added `test_get_history_pagination` covering first page, mid page, partial last page, and out-of-bounds offset

### SDK (`sdk/src/reputation.ts`)
- `getScoreHistory` accepts optional `offset` (default `0`) and `limit` (default `20`)
- Both forwarded as `u32` ScVals to the contract
- JSDoc documents all pagination params

### Tests (`sdk/src/reputation.test.ts`)
- Verifies default `limit=20` / `offset=0` are passed when omitted
- Verifies custom `limit` and `offset` are forwarded correctly
- Existing error and empty-array cases preserved

## Checklist

- [x] Contract supports `limit`/`offset` in `get_history`
- [x] SDK method accepts optional `limit` and `offset`
- [x] Defaults to `limit=20`
- [x] JSDoc added
- [x] Unit tests cover paginated responses
```