### PR TITLE
feat: make transaction timeout configurable via SorobanIdentityConfig

### DIFF
--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -52,7 +52,7 @@ export class CredentialClient {
           nativeToScVal(expiresAt, { type: "u64" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const prepared = await this.server.prepareTransaction(tx);
@@ -89,7 +89,7 @@ export class CredentialClient {
           nativeToScVal(idBytes, { type: "bytes" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);
@@ -121,7 +121,7 @@ export class CredentialClient {
           nativeToScVal(idBytes, { type: "bytes" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);

--- a/sdk/src/identity.ts
+++ b/sdk/src/identity.ts
@@ -44,7 +44,7 @@ export class IdentityClient {
           metaScVal
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const prepared = await this.server.prepareTransaction(tx);
@@ -75,7 +75,7 @@ export class IdentityClient {
           nativeToScVal(controllerAddress, { type: "address" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);
@@ -105,7 +105,7 @@ export class IdentityClient {
           nativeToScVal(controllerAddress, { type: "address" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -48,7 +48,7 @@ export class ReputationClient {
           nativeToScVal(subjectAddress, { type: "address" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);
@@ -92,7 +92,7 @@ export class ReputationClient {
           nativeToScVal(limit, { type: "u32" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);
@@ -126,7 +126,7 @@ export class ReputationClient {
           nativeToScVal(minReporters, { type: "u32" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);
@@ -159,7 +159,7 @@ export class ReputationClient {
           nativeToScVal(reason, { type: "string" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const prepared = await this.server.prepareTransaction(tx);

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -27,4 +27,6 @@ export interface SorobanIdentityConfig {
   identityRegistryId: string;
   credentialManagerId: string;
   reputationId: string;
+  /** Transaction timeout in seconds. Defaults to 30. */
+  txTimeout?: number;
 }


### PR DESCRIPTION
Close #32 

**Title:** `feat: make transaction timeout configurable via SorobanIdentityConfig`

**Body:**

```
## Summary

Replaces all hardcoded `.setTimeout(30)` calls across the SDK with a
configurable `txTimeout` field on `SorobanIdentityConfig`.

## Problem

All SDK clients hardcoded a 30-second transaction timeout. Under slow network
conditions or high ledger load, this could cause transactions to fail
prematurely with no way to adjust it.

## Changes

### `sdk/src/types.ts`
- Added optional `txTimeout?: number` field to `SorobanIdentityConfig`
- Documented with JSDoc comment

### `sdk/src/identity.ts`, `sdk/src/credentials.ts`, `sdk/src/reputation.ts`
- Replaced all 9 hardcoded `.setTimeout(30)` calls with `.setTimeout(this.config.txTimeout ?? 30)`

## Usage

```ts
const client = new IdentityClient({
  rpcUrl: "https://soroban-testnet.stellar.org",
  networkPassphrase: "Test SDF Network ; September 2015",
  identityRegistryId: "CONTRACT_ID",
  credentialManagerId: "CONTRACT_ID",
  reputationId: "CONTRACT_ID",
  txTimeout: 60, // optional, defaults to 30
});
```

## Checklist

- [x] `txTimeout` added to `SorobanIdentityConfig` as optional
- [x] All three SDK clients use the config value
- [x] Defaults to `30` when not set
- [x] Zero type errors across all modified files
```