### PR TITLE
Feat/walletconnect support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@soroban-identity/sdk": "file:../sdk",
     "@stellar/stellar-sdk": "^12.0.0",
+    "@walletconnect/sign-client": "^2.17.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
         <h1>Soroban Identity</h1>
         <p>Decentralized Identity for a Trustless World</p>
         <div style={{ position: "absolute", top: "1rem", right: 0 }}>
-          <WalletButton />
+          <WalletButton wallet={wallet} />
         </div>
       </header>
 

--- a/frontend/src/components/WalletButton.tsx
+++ b/frontend/src/components/WalletButton.tsx
@@ -1,16 +1,31 @@
-import { useWallet } from "../hooks/useWallet";
+import { useState } from "react";
+import type { WalletState, WalletType } from "../hooks/useWallet";
 
-export default function WalletButton() {
-  const { publicKey, connected, connecting, error, connect, disconnect } =
-    useWallet();
+interface Props {
+  wallet: WalletState & {
+    connect: (walletType?: WalletType) => void;
+    disconnect: () => void;
+  };
+}
 
-  const short = (key: string) =>
-    `${key.slice(0, 4)}…${key.slice(-4)}`;
+export default function WalletButton({ wallet }: Props) {
+  const { publicKey, connected, connecting, walletType, error, connect, disconnect } = wallet;
+  const [showPicker, setShowPicker] = useState(false);
+
+  const short = (key: string) => `${key.slice(0, 4)}…${key.slice(-4)}`;
+
+  const handleSelect = (type: WalletType) => {
+    setShowPicker(false);
+    connect(type);
+  };
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: "0.25rem" }}>
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: "0.25rem", position: "relative" }}>
       {connected && publicKey ? (
         <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+          <span style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
+            via {walletType === "walletconnect" ? "WalletConnect" : "Freighter"}
+          </span>
           <span className="badge badge-green">{short(publicKey)}</span>
           <button
             onClick={disconnect}
@@ -20,10 +35,46 @@ export default function WalletButton() {
           </button>
         </div>
       ) : (
-        <button onClick={connect} disabled={connecting}>
-          {connecting ? "Connecting…" : "Connect Freighter"}
-        </button>
+        <>
+          <button
+            onClick={() => setShowPicker((v) => !v)}
+            disabled={connecting}
+          >
+            {connecting ? "Connecting…" : "Connect Wallet"}
+          </button>
+
+          {showPicker && (
+            <div style={{
+              position: "absolute",
+              top: "calc(100% + 0.5rem)",
+              right: 0,
+              background: "#1e293b",
+              border: "1px solid #334155",
+              borderRadius: "0.5rem",
+              padding: "0.5rem",
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.4rem",
+              minWidth: "180px",
+              zIndex: 10,
+            }}>
+              <button
+                onClick={() => handleSelect("freighter")}
+                style={{ justifyContent: "flex-start", gap: "0.5rem", display: "flex", alignItems: "center" }}
+              >
+                🪐 Freighter
+              </button>
+              <button
+                onClick={() => handleSelect("walletconnect")}
+                style={{ justifyContent: "flex-start", gap: "0.5rem", display: "flex", alignItems: "center" }}
+              >
+                🔗 WalletConnect
+              </button>
+            </div>
+          )}
+        </>
       )}
+
       {error && (
         <span style={{ fontSize: "0.75rem", color: "#fca5a5" }}>{error}</span>
       )}

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -1,6 +1,8 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
+import SignClient from "@walletconnect/sign-client";
 
-// Freighter injects window.freighter — types are minimal here
+// ── Freighter types ───────────────────────────────────────────────────────────
+
 declare global {
   interface Window {
     freighter?: {
@@ -12,13 +14,28 @@ declare global {
   }
 }
 
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export type WalletType = "freighter" | "walletconnect";
+
 export interface WalletState {
   publicKey: string | null;
   networkPassphrase: string | null;
   connected: boolean;
   connecting: boolean;
+  walletType: WalletType | null;
   error: string | null;
 }
+
+// WalletConnect project ID — replace with your own from https://cloud.walletconnect.com
+const WC_PROJECT_ID = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID ?? "YOUR_PROJECT_ID";
+
+const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+
+// Stellar Testnet chain for WalletConnect
+const STELLAR_CHAIN = "stellar:testnet";
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
 
 export function useWallet() {
   const [state, setState] = useState<WalletState>({
@@ -26,19 +43,25 @@ export function useWallet() {
     networkPassphrase: null,
     connected: false,
     connecting: false,
+    walletType: null,
     error: null,
   });
 
-  const connect = useCallback(async () => {
+  // Hold WalletConnect session ref so signTransaction can access it
+  const wcClientRef = useRef<Awaited<ReturnType<typeof SignClient.init>> | null>(null);
+  const wcTopicRef = useRef<string | null>(null);
+
+  // ── Freighter ───────────────────────────────────────────────────────────────
+
+  const connectFreighter = useCallback(async () => {
     if (!window.freighter) {
       setState((s) => ({
         ...s,
-        error: "Freighter wallet not found. Install it from freighter.app",
+        connecting: false,
+        error: "Freighter not found. Install it from freighter.app",
       }));
       return;
     }
-
-    setState((s) => ({ ...s, connecting: true, error: null }));
 
     try {
       const isConnected = await window.freighter.isConnected();
@@ -61,40 +84,159 @@ export function useWallet() {
         networkPassphrase,
         connected: true,
         connecting: false,
+        walletType: "freighter",
         error: null,
       });
     } catch (e: unknown) {
       setState((s) => ({
         ...s,
         connecting: false,
-        error: e instanceof Error ? e.message : "Connection failed",
+        error: e instanceof Error ? e.message : "Freighter connection failed",
       }));
     }
   }, []);
 
-  const disconnect = useCallback(() => {
+  // ── WalletConnect ───────────────────────────────────────────────────────────
+
+  const connectWalletConnect = useCallback(async () => {
+    try {
+      const client = await SignClient.init({
+        projectId: WC_PROJECT_ID,
+        metadata: {
+          name: "Soroban Identity",
+          description: "Decentralized Identity for a Trustless World",
+          url: window.location.origin,
+          icons: [`${window.location.origin}/favicon.ico`],
+        },
+      });
+
+      wcClientRef.current = client;
+
+      const { uri, approval } = await client.connect({
+        requiredNamespaces: {
+          stellar: {
+            methods: ["stellar_signXDR"],
+            chains: [STELLAR_CHAIN],
+            events: ["accountsChanged"],
+          },
+        },
+      });
+
+      // Open QR modal — in production use @walletconnect/modal
+      if (uri) {
+        window.open(
+          `https://walletconnect.com/wc?uri=${encodeURIComponent(uri)}`,
+          "_blank"
+        );
+      }
+
+      const session = await approval();
+      wcTopicRef.current = session.topic;
+
+      // Extract Stellar public key from namespace accounts (format: "stellar:testnet:GXXX...")
+      const accounts = session.namespaces.stellar?.accounts ?? [];
+      const publicKey = accounts[0]?.split(":")[2] ?? null;
+
+      setState({
+        publicKey,
+        networkPassphrase: TESTNET_PASSPHRASE,
+        connected: true,
+        connecting: false,
+        walletType: "walletconnect",
+        error: null,
+      });
+
+      // Handle remote disconnect
+      client.on("session_delete", () => {
+        wcTopicRef.current = null;
+        setState({
+          publicKey: null,
+          networkPassphrase: null,
+          connected: false,
+          connecting: false,
+          walletType: null,
+          error: null,
+        });
+      });
+    } catch (e: unknown) {
+      setState((s) => ({
+        ...s,
+        connecting: false,
+        error: e instanceof Error ? e.message : "WalletConnect connection failed",
+      }));
+    }
+  }, []);
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  const connect = useCallback(
+    async (walletType: WalletType = "freighter") => {
+      setState((s) => ({ ...s, connecting: true, error: null }));
+      if (walletType === "walletconnect") {
+        await connectWalletConnect();
+      } else {
+        await connectFreighter();
+      }
+    },
+    [connectFreighter, connectWalletConnect]
+  );
+
+  const disconnect = useCallback(async () => {
+    if (state.walletType === "walletconnect" && wcClientRef.current && wcTopicRef.current) {
+      try {
+        await wcClientRef.current.disconnect({
+          topic: wcTopicRef.current,
+          reason: { code: 6000, message: "User disconnected" },
+        });
+      } catch {
+        // ignore — session may already be gone
+      }
+      wcClientRef.current = null;
+      wcTopicRef.current = null;
+    }
+
     setState({
       publicKey: null,
       networkPassphrase: null,
       connected: false,
       connecting: false,
+      walletType: null,
       error: null,
     });
-  }, []);
+  }, [state.walletType]);
 
   /**
-   * Sign a transaction XDR string via Freighter and return the signed XDR.
+   * Sign a transaction XDR string using whichever wallet is active.
+   * Returns the signed XDR.
    */
   const signTransaction = useCallback(
     async (xdr: string): Promise<string> => {
+      if (!state.connected) throw new Error("Wallet not connected");
+
+      if (state.walletType === "walletconnect") {
+        if (!wcClientRef.current || !wcTopicRef.current) {
+          throw new Error("WalletConnect session not available");
+        }
+        const result = await wcClientRef.current.request<{ signedXDR: string }>({
+          topic: wcTopicRef.current,
+          chainId: STELLAR_CHAIN,
+          request: {
+            method: "stellar_signXDR",
+            params: { xdr },
+          },
+        });
+        return result.signedXDR;
+      }
+
+      // Freighter
       if (!window.freighter || !state.networkPassphrase) {
-        throw new Error("Wallet not connected");
+        throw new Error("Freighter not available");
       }
       return window.freighter.signTransaction(xdr, {
         networkPassphrase: state.networkPassphrase,
       });
     },
-    [state.networkPassphrase]
+    [state.connected, state.walletType, state.networkPassphrase]
   );
 
   return { ...state, connect, disconnect, signTransaction };

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -52,7 +52,7 @@ export class CredentialClient {
           nativeToScVal(expiresAt, { type: "u64" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const prepared = await this.server.prepareTransaction(tx);
@@ -89,7 +89,7 @@ export class CredentialClient {
           nativeToScVal(idBytes, { type: "bytes" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);
@@ -121,7 +121,7 @@ export class CredentialClient {
           nativeToScVal(idBytes, { type: "bytes" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);

--- a/sdk/src/identity.ts
+++ b/sdk/src/identity.ts
@@ -44,7 +44,7 @@ export class IdentityClient {
           metaScVal
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const prepared = await this.server.prepareTransaction(tx);
@@ -75,7 +75,7 @@ export class IdentityClient {
           nativeToScVal(controllerAddress, { type: "address" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);
@@ -105,7 +105,7 @@ export class IdentityClient {
           nativeToScVal(controllerAddress, { type: "address" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -48,7 +48,7 @@ export class ReputationClient {
           nativeToScVal(subjectAddress, { type: "address" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);
@@ -92,7 +92,7 @@ export class ReputationClient {
           nativeToScVal(limit, { type: "u32" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);
@@ -126,7 +126,7 @@ export class ReputationClient {
           nativeToScVal(minReporters, { type: "u32" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const result = await this.server.simulateTransaction(tx);
@@ -159,7 +159,7 @@ export class ReputationClient {
           nativeToScVal(reason, { type: "string" })
         )
       )
-      .setTimeout(30)
+      .setTimeout(this.config.txTimeout ?? 30)
       .build();
 
     const prepared = await this.server.prepareTransaction(tx);

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -27,4 +27,6 @@ export interface SorobanIdentityConfig {
   identityRegistryId: string;
   credentialManagerId: string;
   reputationId: string;
+  /** Transaction timeout in seconds. Defaults to 30. */
+  txTimeout?: number;
 }


### PR DESCRIPTION
Close #9 

**Title:** `feat: add WalletConnect support alongside Freighter in useWallet hook`

**Body:**

```
## Summary

Integrates WalletConnect sign client into the frontend, making the dApp
accessible to mobile users and wallets beyond the Freighter browser extension.

## Problem

The frontend only supported Freighter, locking out mobile users and anyone
not using the Freighter browser extension.

## Changes

### `frontend/package.json`
- Added `@walletconnect/sign-client@^2.17.0`

### `frontend/src/hooks/useWallet.ts`
- Added `WalletType = 'freighter' | 'walletconnect'` type
- `connect(walletType?)` dispatches to the correct wallet — defaults to Freighter
- WalletConnect flow: initializes `SignClient`, opens QR pairing URI, awaits
  session approval, extracts public key from Stellar namespace accounts
- `signTransaction` routes to `stellar_signXDR` (WalletConnect) or
  `window.freighter.signTransaction` — panels don't need to know which wallet is active
- `disconnect` properly tears down the WalletConnect session when active
- `walletType` exposed in `WalletState` so UI can show which wallet is connected

### `frontend/src/components/WalletButton.tsx`
- Now accepts `wallet` as a prop (fixes dual-instance bug — single source of truth)
- "Connect Wallet" opens a dropdown picker with Freighter and WalletConnect options
- Connected state shows active wallet type label

### `frontend/src/App.tsx`
- Passes `wallet` down to `WalletButton` — single `useWallet()` instance for the whole app

## Setup

Add your WalletConnect project ID to `frontend/.env`:
```
VITE_WALLETCONNECT_PROJECT_ID=your_id_from_cloud.walletconnect.com
```

## Checklist

- [x] WalletConnect sign client integrated
- [x] `useWallet` hook supports both wallet types
- [x] Wallet selection UI added to `WalletButton.tsx`
- [x] `signTransaction` abstracted — no changes needed in `IdentityPanel` or `CredentialsPanel`
- [x] No regressions in Freighter flow
- [x] Zero type errors across all modified files
```