### PR TITLE
Add getCredentialsBySubject method to CredentialClient

### DIFF
--- a/sdk/src/credentials.test.ts
+++ b/sdk/src/credentials.test.ts
@@ -51,6 +51,7 @@ const config: SorobanIdentityConfig = {
   networkPassphrase: "Test SDF Network ; September 2015",
   identityRegistryId: "CONTRACT_A",
   credentialManagerId: "CONTRACT_B",
+  reputationId: "CONTRACT_C",
 };
 
 describe("CredentialClient", () => {
@@ -67,5 +68,47 @@ describe("CredentialClient", () => {
   it("verifyCredential returns a boolean", async () => {
     const result = await client.verifyCredential("GABC", "aabbcc");
     expect(typeof result).toBe("boolean");
+  });
+
+  it("getCredentialsBySubject — returns empty array when subject has no credentials", async () => {
+    const server = (client as any).server;
+    server.simulateTransaction.mockResolvedValueOnce({
+      result: { retval: [] },
+    });
+
+    const result = await client.getCredentialsBySubject("GABC", "GSUBJECT");
+
+    expect(result).toEqual([]);
+  });
+
+  it("getCredentialsBySubject — returns Credential[] for each ID", async () => {
+    const mockCredential = {
+      id: "aabbcc",
+      subject: "GSUBJECT",
+      issuer: "GABC",
+      credentialType: "Kyc",
+      claims: {},
+      signature: "",
+      issuedAt: 1000,
+      expiresAt: 0,
+      revoked: false,
+    };
+
+    const server = (client as any).server;
+
+    // First simulate call returns a list of one ID
+    server.simulateTransaction
+      .mockResolvedValueOnce({
+        result: { retval: [new Uint8Array(32)] },
+      })
+      // Second simulate call (getCredential) returns the credential
+      .mockResolvedValueOnce({
+        result: { retval: mockCredential },
+      });
+
+    const result = await client.getCredentialsBySubject("GABC", "GSUBJECT");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(mockCredential);
   });
 });

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -102,6 +102,51 @@ export class CredentialClient {
   }
 
   /**
+   * Get all credentials issued to a subject address.
+   */
+  async getCredentialsBySubject(
+    callerAddress: string,
+    subjectAddress: string
+  ): Promise<Credential[]> {
+    const account = await this.server.getAccount(callerAddress);
+
+    // Fetch the list of credential IDs for the subject
+    const idsTx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          "get_subject_credentials",
+          nativeToScVal(subjectAddress, { type: "address" })
+        )
+      )
+      .setTimeout(this.config.txTimeout ?? 30)
+      .build();
+
+    const idsResult = await this.server.simulateTransaction(idsTx);
+    if (SorobanRpc.Api.isSimulationError(idsResult)) {
+      throw new Error(`Simulation failed: ${idsResult.error}`);
+    }
+
+    const ids = scValToNative(
+      (idsResult as SorobanRpc.Api.SimulateTransactionSuccessResponse)
+        .result!.retval
+    ) as Uint8Array[];
+
+    if (!ids || ids.length === 0) return [];
+
+    // Resolve each credential by ID
+    const credentials = await Promise.all(
+      ids.map((raw) =>
+        this.getCredential(callerAddress, Buffer.from(raw).toString("hex"))
+      )
+    );
+
+    return credentials;
+  }
+
+  /**
    * Get a credential by ID.
    */
   async getCredential(


### PR DESCRIPTION
## Summary

Adds `getCredentialsBySubject(callerAddress, subjectAddress)` to `CredentialClient` in `sdk/src/credentials.ts`.

The `credential-manager` contract already indexes credentials under each subject via `get_subject_credentials`, so no contract changes were needed. The SDK method calls that function to retrieve the list of credential IDs, then resolves each one in parallel via the existing `getCredential` method.

this pr Closes #4 

## Changes

- `sdk/src/credentials.ts` — added `getCredentialsBySubject`, returns `Credential[]`. Follows the same simulate pattern as other read methods. Returns an empty array when the subject has no credentials.

- `sdk/src/credentials.test.ts` — added two tests:
  - empty subject returns `[]`
  - subject with one credential returns a correctly typed `Credential[]`
  Also fixed missing `reputationId` in the test config fixture.

## Notes

No new types needed — `Credential[]` uses the existing `Credential` type already exported from `sdk/src/index.ts`.

## Definition of Done

- [x] `getCredentialsBySubject` implemented in `CredentialClient`
- [x] Returns `Credential[]` typed correctly
- [x] Unit tests added
- [ ] `npm run build` passes (run locally to verify)
