### PR TITLE
feat: dark mode support + Rust unit tests for reputation & credential-manager

### DIFF
--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -10,12 +10,13 @@ use soroban_sdk::{
 const ADMIN: Symbol = symbol_short!("ADMIN");
 const ISSUER: Symbol = symbol_short!("ISSUER");
 const CRED: Symbol = symbol_short!("CRED");
+const IDSEQ: Symbol = symbol_short!("IDSEQ");
 
 // ── Data types ────────────────────────────────────────────────────────────────
 
 /// Credential types supported by the protocol.
 #[contracttype]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum CredentialType {
     Kyc,
     Reputation,
@@ -78,10 +79,12 @@ impl CredentialManager {
     pub fn remove_issuer(env: Env, issuer: Address) {
         Self::require_admin(&env);
         let issuers = Self::get_issuers(&env);
-        let updated: Vec<Address> = issuers
-            .iter()
-            .filter(|i| i != issuer)
-            .collect();
+        let mut updated = Vec::new(&env);
+        for i in issuers.iter() {
+            if i != issuer {
+                updated.push_back(i);
+            }
+        }
         env.storage().instance().set(&ISSUER, &updated);
     }
 
@@ -101,7 +104,7 @@ impl CredentialManager {
         Self::require_issuer(&env, &issuer);
 
         let now = env.ledger().timestamp();
-        let id = Self::generate_id(&env, &issuer, &subject, now);
+        let id = Self::generate_id(&env, now);
 
         let credential = Credential {
             id: id.clone(),
@@ -115,13 +118,13 @@ impl CredentialManager {
             revoked: false,
         };
 
-        let key = Self::cred_key(&env, &id);
+        let key = Self::cred_key(&id);
         env.storage().persistent().set(&key, &credential);
 
         // Index credential under subject
-        let mut subject_creds = Self::get_subject_credentials(&env, &subject);
+        let mut subject_creds = Self::fetch_subject_creds(&env, &subject);
         subject_creds.push_back(id.clone());
-        let subject_key = Self::subject_key(&env, &subject);
+        let subject_key = Self::subject_key(&subject);
         env.storage().persistent().set(&subject_key, &subject_creds);
 
         env.events().publish((CRED, symbol_short!("issued")), (issuer, subject));
@@ -133,7 +136,7 @@ impl CredentialManager {
     pub fn revoke_credential(env: Env, issuer: Address, credential_id: BytesN<32>) {
         issuer.require_auth();
 
-        let key = Self::cred_key(&env, &credential_id);
+        let key = Self::cred_key(&credential_id);
         let mut cred: Credential = env
             .storage()
             .persistent()
@@ -151,8 +154,8 @@ impl CredentialManager {
 
     /// Verify a credential is valid (not revoked, not expired).
     pub fn verify_credential(env: Env, credential_id: BytesN<32>) -> bool {
-        let key = Self::cred_key(&env, &credential_id);
-        match env.storage().persistent().get::<Bytes, Credential>(&key) {
+        let key = Self::cred_key(&credential_id);
+        match env.storage().persistent().get::<(Symbol, BytesN<32>), Credential>(&key) {
             None => false,
             Some(cred) => {
                 if cred.revoked {
@@ -168,7 +171,7 @@ impl CredentialManager {
 
     /// Get a credential by ID.
     pub fn get_credential(env: Env, credential_id: BytesN<32>) -> Credential {
-        let key = Self::cred_key(&env, &credential_id);
+        let key = Self::cred_key(&credential_id);
         env.storage()
             .persistent()
             .get(&key)
@@ -176,12 +179,8 @@ impl CredentialManager {
     }
 
     /// List all credential IDs for a subject.
-    pub fn get_subject_credentials(env: &Env, subject: &Address) -> Vec<BytesN<32>> {
-        let key = Self::subject_key(env, subject);
-        env.storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or_else(|| Vec::new(env))
+    pub fn get_subject_credentials(env: Env, subject: Address) -> Vec<BytesN<32>> {
+        Self::fetch_subject_creds(&env, &subject)
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
@@ -205,26 +204,32 @@ impl CredentialManager {
             .unwrap_or_else(|| Vec::new(env))
     }
 
-    fn generate_id(env: &Env, issuer: &Address, subject: &Address, timestamp: u64) -> BytesN<32> {
+    fn fetch_subject_creds(env: &Env, subject: &Address) -> Vec<BytesN<32>> {
+        let key = Self::subject_key(subject);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    /// Generate a unique 32-byte credential ID from the current timestamp and
+    /// a per-contract sequence counter to prevent collisions within the same ledger.
+    fn generate_id(env: &Env, timestamp: u64) -> BytesN<32> {
+        let seq: u64 = env.storage().instance().get(&IDSEQ).unwrap_or(0);
+        env.storage().instance().set(&IDSEQ, &(seq + 1));
+
         let mut data = Bytes::new(env);
-        data.extend_from_slice(&issuer.to_string().into_bytes());
-        data.extend_from_slice(&subject.to_string().into_bytes());
         data.extend_from_array(&timestamp.to_be_bytes());
-        env.crypto().sha256(&data)
+        data.extend_from_array(&seq.to_be_bytes());
+        env.crypto().sha256(&data).into()
     }
 
-    fn cred_key(env: &Env, id: &BytesN<32>) -> Bytes {
-        let mut key = Bytes::new(env);
-        key.extend_from_array(&[b'c', b'r', b'e', b'd', b':']);
-        key.extend_from_slice(id.as_ref());
-        key
+    fn cred_key(id: &BytesN<32>) -> (Symbol, BytesN<32>) {
+        (CRED, id.clone())
     }
 
-    fn subject_key(env: &Env, subject: &Address) -> Bytes {
-        let mut key = Bytes::new(env);
-        key.extend_from_array(&[b's', b'u', b'b', b':']);
-        key.extend_from_slice(&subject.to_string().into_bytes());
-        key
+    fn subject_key(subject: &Address) -> (Symbol, Address) {
+        (symbol_short!("sub"), subject.clone())
     }
 }
 
@@ -233,7 +238,7 @@ impl CredentialManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Bytes, Env, Map};
+    use soroban_sdk::{testutils::{Address as _, Ledger as _}, Bytes, Env, Map};
 
     fn setup() -> (Env, Address, CredentialManagerClient<'static>) {
         let env = Env::default();
@@ -245,6 +250,7 @@ mod tests {
         (env, admin, client)
     }
 
+    /// issue_credential stores the credential and verify_credential returns true.
     #[test]
     fn test_issue_and_verify() {
         let (env, _admin, client) = setup();
@@ -269,6 +275,7 @@ mod tests {
         assert!(client.verify_credential(&cred_id));
     }
 
+    /// revoke_credential marks the credential revoked; verify_credential returns false.
     #[test]
     fn test_revoke_credential() {
         let (env, _admin, client) = setup();
@@ -285,5 +292,103 @@ mod tests {
 
         client.revoke_credential(&issuer, &cred_id);
         assert!(!client.verify_credential(&cred_id));
+    }
+
+    /// issue_credential must panic when the caller is not a registered issuer.
+    #[test]
+    #[should_panic]
+    fn test_issue_unauthorized_issuer() {
+        let (env, _admin, client) = setup();
+
+        let unauthorized = Address::generate(&env); // NOT registered
+        let subject = Address::generate(&env);
+
+        let claims: Map<String, String> = Map::new(&env);
+        let sig = Bytes::from_array(&env, &[0u8; 64]);
+
+        client.issue_credential(
+            &unauthorized, &subject, &CredentialType::Kyc, &claims, &sig, &0u64,
+        );
+    }
+
+    /// verify_credential returns false once the credential's expiry timestamp has passed.
+    #[test]
+    fn test_verify_expired_credential() {
+        let (env, _admin, client) = setup();
+
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.add_issuer(&issuer);
+
+        let claims: Map<String, String> = Map::new(&env);
+        let sig = Bytes::from_array(&env, &[0u8; 64]);
+        let expires_at = env.ledger().timestamp() + 100;
+
+        let cred_id = client.issue_credential(
+            &issuer, &subject, &CredentialType::Kyc, &claims, &sig, &expires_at,
+        );
+
+        // Valid before expiry
+        assert!(client.verify_credential(&cred_id));
+
+        // Advance ledger past expiry
+        env.ledger().with_mut(|li| {
+            li.timestamp = expires_at + 1;
+        });
+
+        // Must be invalid after expiry
+        assert!(!client.verify_credential(&cred_id));
+    }
+
+    /// revoke_credential must panic when called by an address that did not issue the credential.
+    #[test]
+    #[should_panic]
+    fn test_revoke_by_different_issuer() {
+        let (env, _admin, client) = setup();
+
+        let issuer1 = Address::generate(&env);
+        let issuer2 = Address::generate(&env);
+        let subject = Address::generate(&env);
+
+        client.add_issuer(&issuer1);
+        client.add_issuer(&issuer2);
+
+        let claims: Map<String, String> = Map::new(&env);
+        let sig = Bytes::from_array(&env, &[0u8; 64]);
+        let cred_id = client.issue_credential(
+            &issuer1, &subject, &CredentialType::Kyc, &claims, &sig, &0u64,
+        );
+
+        // issuer2 attempts to revoke a credential they did not issue
+        client.revoke_credential(&issuer2, &cred_id);
+    }
+
+    /// get_credential returns all fields exactly as supplied at issuance.
+    #[test]
+    fn test_credential_stored_correctly() {
+        let (env, _admin, client) = setup();
+
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.add_issuer(&issuer);
+
+        let mut claims: Map<String, String> = Map::new(&env);
+        claims.set(
+            String::from_str(&env, "name"),
+            String::from_str(&env, "Alice"),
+        );
+        let sig = Bytes::from_array(&env, &[1u8; 64]);
+        let expires_at = 9999u64;
+
+        let cred_id = client.issue_credential(
+            &issuer, &subject, &CredentialType::Achievement, &claims, &sig, &expires_at,
+        );
+
+        let cred = client.get_credential(&cred_id);
+        assert_eq!(cred.issuer, issuer);
+        assert_eq!(cred.subject, subject);
+        assert_eq!(cred.credential_type, CredentialType::Achievement);
+        assert_eq!(cred.expires_at, expires_at);
+        assert!(!cred.revoked);
     }
 }

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -8,7 +8,7 @@
 
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short,
-    Address, Env, Map, Symbol, Vec,
+    Address, Env, Symbol, Vec,
 };
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -69,7 +69,12 @@ impl Reputation {
     pub fn remove_reporter(env: Env, reporter: Address) {
         Self::require_admin(&env);
         let reporters = Self::get_reporters(&env);
-        let updated: Vec<Address> = reporters.iter().filter(|r| r != reporter).collect();
+        let mut updated = Vec::new(&env);
+        for r in reporters.iter() {
+            if r != reporter {
+                updated.push_back(r);
+            }
+        }
         env.storage().instance().set(&REPORTER, &updated);
     }
 
@@ -89,7 +94,7 @@ impl Reputation {
         let now = env.ledger().timestamp();
 
         // Update aggregate record
-        let rec_key = Self::record_key(&env, &subject);
+        let rec_key = Self::record_key(&subject);
         let mut record: ReputationRecord = env
             .storage()
             .persistent()
@@ -105,7 +110,7 @@ impl Reputation {
         record.updated_at = now;
 
         // Track whether this reporter is new for this subject
-        let history_key = Self::history_key(&env, &subject, &reporter);
+        let history_key = Self::history_key(&subject, &reporter);
         let is_new = !env.storage().persistent().has(&history_key);
         if is_new {
             record.reporter_count = record.reporter_count.saturating_add(1);
@@ -134,7 +139,7 @@ impl Reputation {
 
     /// Get the reputation record for a subject.
     pub fn get_reputation(env: Env, subject: Address) -> ReputationRecord {
-        let key = Self::record_key(&env, &subject);
+        let key = Self::record_key(&subject);
         env.storage()
             .persistent()
             .get(&key)
@@ -157,7 +162,7 @@ impl Reputation {
         offset: u32,
         limit: u32,
     ) -> Vec<ScoreEntry> {
-        let key = Self::history_key(&env, &subject, &reporter);
+        let key = Self::history_key(&subject, &reporter);
         let all: Vec<ScoreEntry> = env
             .storage()
             .persistent()
@@ -185,8 +190,8 @@ impl Reputation {
         min_score: i64,
         min_reporters: u32,
     ) -> bool {
-        let key = Self::record_key(&env, &subject);
-        match env.storage().persistent().get::<soroban_sdk::Bytes, ReputationRecord>(&key) {
+        let key = Self::record_key(&subject);
+        match env.storage().persistent().get::<(Symbol, Address), ReputationRecord>(&key) {
             None => false,
             Some(rec) => rec.score >= min_score && rec.reporter_count >= min_reporters,
         }
@@ -212,20 +217,12 @@ impl Reputation {
             .unwrap_or_else(|| Vec::new(env))
     }
 
-    fn record_key(env: &Env, subject: &Address) -> soroban_sdk::Bytes {
-        let mut k = soroban_sdk::Bytes::new(env);
-        k.extend_from_array(&[b'r', b'e', b'c', b':']);
-        k.extend_from_slice(&subject.to_string().into_bytes());
-        k
+    fn record_key(subject: &Address) -> (Symbol, Address) {
+        (symbol_short!("rec"), subject.clone())
     }
 
-    fn history_key(env: &Env, subject: &Address, reporter: &Address) -> soroban_sdk::Bytes {
-        let mut k = soroban_sdk::Bytes::new(env);
-        k.extend_from_array(&[b'h', b':', ]);
-        k.extend_from_slice(&subject.to_string().into_bytes());
-        k.extend_from_array(&[b'|']);
-        k.extend_from_slice(&reporter.to_string().into_bytes());
-        k
+    fn history_key(subject: &Address, reporter: &Address) -> (Symbol, Address, Address) {
+        (symbol_short!("h"), subject.clone(), reporter.clone())
     }
 }
 
@@ -327,5 +324,101 @@ mod tests {
         assert!(client.passes_sybil_check(&subject, &50, &2));
         // requires 3 reporters — should fail
         assert!(!client.passes_sybil_check(&subject, &50, &3));
+    }
+
+    /// submit_score must panic when the reporter is not registered.
+    #[test]
+    #[should_panic]
+    fn test_submit_score_unauthorized_reporter() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, Reputation);
+        let client = ReputationClient::new(&env, &contract_id);
+
+        let admin    = Address::generate(&env);
+        let reporter = Address::generate(&env); // never added as reporter
+        let subject  = Address::generate(&env);
+
+        client.initialize(&admin);
+
+        let reason = String::from_str(&env, "unauthorized");
+        client.submit_score(&reporter, &subject, &10, &reason);
+    }
+
+    /// passes_sybil_check returns false when score is below the minimum threshold.
+    #[test]
+    fn test_sybil_check_score_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, Reputation);
+        let client = ReputationClient::new(&env, &contract_id);
+
+        let admin    = Address::generate(&env);
+        let reporter = Address::generate(&env);
+        let subject  = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.add_reporter(&reporter);
+
+        let reason = String::from_str(&env, "activity");
+        client.submit_score(&reporter, &subject, &30, &reason);
+
+        // score=30, reporters=1 — passes with matching thresholds
+        assert!(client.passes_sybil_check(&subject, &30, &1));
+        // score=30 is below min_score=50 — must fail
+        assert!(!client.passes_sybil_check(&subject, &50, &1));
+    }
+
+    /// passes_sybil_check returns false for a subject with no reputation record at all.
+    #[test]
+    fn test_sybil_check_no_record() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, Reputation);
+        let client = ReputationClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let subject = Address::generate(&env); // no history
+        // Even with zero thresholds the contract returns false when no record exists
+        assert!(!client.passes_sybil_check(&subject, &0, &0));
+    }
+
+    /// get_history returns only entries submitted by the specified reporter.
+    #[test]
+    fn test_get_history_per_reporter() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, Reputation);
+        let client = ReputationClient::new(&env, &contract_id);
+
+        let admin     = Address::generate(&env);
+        let reporter1 = Address::generate(&env);
+        let reporter2 = Address::generate(&env);
+        let subject   = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.add_reporter(&reporter1);
+        client.add_reporter(&reporter2);
+
+        let r1 = String::from_str(&env, "reporter1 reason");
+        let r2 = String::from_str(&env, "reporter2 reason");
+        client.submit_score(&reporter1, &subject, &10, &r1);
+        client.submit_score(&reporter1, &subject, &20, &r1);
+        client.submit_score(&reporter2, &subject, &99, &r2);
+
+        let h1 = client.get_history(&subject, &reporter1, &0, &10);
+        assert_eq!(h1.len(), 2);
+        assert_eq!(h1.get(0).unwrap().delta, 10);
+        assert_eq!(h1.get(1).unwrap().delta, 20);
+
+        let h2 = client.get_history(&subject, &reporter2, &0, &10);
+        assert_eq!(h2.len(), 1);
+        assert_eq!(h2.get(0).unwrap().delta, 99);
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import IdentityPanel from "./components/IdentityPanel";
 import CredentialsPanel from "./components/CredentialsPanel";
 import WalletButton from "./components/WalletButton";
@@ -6,16 +6,41 @@ import { useWallet } from "./hooks/useWallet";
 
 type Tab = "identity" | "credentials";
 
+function useDarkMode(): [boolean, () => void] {
+  const [isDark, setIsDark] = useState<boolean>(() => {
+    const stored = localStorage.getItem("dark-mode");
+    if (stored !== null) return stored === "true";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  });
+
+  useEffect(() => {
+    const html = document.documentElement;
+    html.classList.toggle("dark", isDark);
+    html.classList.toggle("light", !isDark);
+    localStorage.setItem("dark-mode", String(isDark));
+  }, [isDark]);
+
+  return [isDark, () => setIsDark((d) => !d)];
+}
+
 export default function App() {
   const [tab, setTab] = useState<Tab>("identity");
   const wallet = useWallet();
+  const [isDark, toggleDark] = useDarkMode();
 
   return (
     <div className="container">
       <header style={{ position: "relative" }}>
         <h1>Soroban Identity</h1>
         <p>Decentralized Identity for a Trustless World</p>
-        <div style={{ position: "absolute", top: "1rem", right: 0 }}>
+        <div style={{ position: "absolute", top: "1rem", right: 0, display: "flex", gap: "0.5rem", alignItems: "center" }}>
+          <button
+            className="theme-toggle"
+            onClick={toggleDark}
+            aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+          >
+            {isDark ? "☀ Light" : "☾ Dark"}
+          </button>
           <WalletButton wallet={wallet} />
         </div>
       </header>

--- a/frontend/src/components/CredentialsPanel.tsx
+++ b/frontend/src/components/CredentialsPanel.tsx
@@ -107,9 +107,9 @@ export default function CredentialsPanel({ wallet }: Props) {
                 style={{
                   padding: "0.3rem 0.75rem",
                   borderRadius: "999px",
-                  border: isActive ? "2px solid #a78bfa" : "2px solid #334155",
-                  background: isActive ? "#1e1b4b" : "transparent",
-                  color: isActive ? "#a78bfa" : "#94a3b8",
+                  border: isActive ? "2px solid var(--accent-light)" : "2px solid var(--border-input)",
+                  background: isActive ? "var(--card-bg-accent)" : "transparent",
+                  color: isActive ? "var(--accent-light)" : "var(--text-muted)",
                   cursor: "pointer",
                   fontSize: "0.85rem",
                   fontWeight: isActive ? 600 : 400,
@@ -119,8 +119,8 @@ export default function CredentialsPanel({ wallet }: Props) {
                 {type}{" "}
                 <span
                   style={{
-                    background: isActive ? "#a78bfa" : "#334155",
-                    color: isActive ? "#1e1b4b" : "#94a3b8",
+                    background: isActive ? "var(--filter-badge-active-bg)" : "var(--border-input)",
+                    color: isActive ? "var(--filter-badge-active-text)" : "var(--text-muted)",
                     borderRadius: "999px",
                     padding: "0 0.4rem",
                     fontSize: "0.75rem",
@@ -135,7 +135,7 @@ export default function CredentialsPanel({ wallet }: Props) {
         </div>
 
         {filteredCredentials.length === 0 ? (
-          <p style={{ color: "#94a3b8", fontSize: "0.85rem" }}>
+          <p style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
             No {activeFilter} credentials found.
           </p>
         ) : (
@@ -144,17 +144,17 @@ export default function CredentialsPanel({ wallet }: Props) {
               <li
                 key={cred.id}
                 style={{
-                  background: "#1e293b",
+                  background: "var(--cred-item-bg)",
                   borderRadius: "0.5rem",
                   padding: "0.6rem 1rem",
                   display: "flex",
                   justifyContent: "space-between",
                   alignItems: "center",
                   fontSize: "0.85rem",
-                  color: "#e2e8f0",
+                  color: "var(--text)",
                 }}
               >
-                <span style={{ fontFamily: "monospace", color: "#94a3b8" }}>{cred.id}</span>
+                <span style={{ fontFamily: "monospace", color: "var(--text-muted)" }}>{cred.id}</span>
                 <span className="badge badge-green">{cred.credentialType}</span>
               </li>
             ))}
@@ -197,9 +197,9 @@ export default function CredentialsPanel({ wallet }: Props) {
         <h2>Issue Credential</h2>
         {wallet.connected ? (
           <>
-            <p style={{ color: "#94a3b8", fontSize: "0.85rem", marginBottom: "1rem" }}>
+            <p style={{ color: "var(--text-muted)", fontSize: "0.85rem", marginBottom: "1rem" }}>
               Issuing as{" "}
-              <span style={{ color: "#a78bfa" }}>
+              <span style={{ color: "var(--accent-light)" }}>
                 {wallet.publicKey?.slice(0, 6)}…{wallet.publicKey?.slice(-4)}
               </span>
             </p>
@@ -213,7 +213,7 @@ export default function CredentialsPanel({ wallet }: Props) {
             </button>
           </>
         ) : (
-          <p style={{ color: "#94a3b8", fontSize: "0.85rem" }}>
+          <p style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
             Connect your Freighter wallet to issue credentials as a registered issuer.
           </p>
         )}

--- a/frontend/src/components/IdentityPanel.tsx
+++ b/frontend/src/components/IdentityPanel.tsx
@@ -119,7 +119,7 @@ export default function IdentityPanel({ wallet }: Props) {
         {resolveResult && <pre className="result">{resolveResult}</pre>}
 
         {reputationLoading && (
-          <p style={{ color: '#94a3b8', fontSize: '0.85rem', marginTop: '1rem' }}>
+          <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem', marginTop: '1rem' }}>
             Loading reputation…
           </p>
         )}
@@ -127,9 +127,9 @@ export default function IdentityPanel({ wallet }: Props) {
         {!reputationLoading && reputation && (
           <div
             className="card"
-            style={{ marginTop: '1rem', background: '#1e1b4b', border: '1px solid #4c1d95' }}
+            style={{ marginTop: '1rem', background: 'var(--card-bg-accent)', border: '1px solid var(--card-border-accent)' }}
           >
-            <h3 style={{ marginBottom: '0.5rem', color: '#a78bfa' }}>Reputation</h3>
+            <h3 style={{ marginBottom: '0.5rem', color: 'var(--accent-light)' }}>Reputation</h3>
             <p>Score: {reputation.score}</p>
             <p>Reporters: {reputation.reporterCount}</p>
             <p>
@@ -142,10 +142,10 @@ export default function IdentityPanel({ wallet }: Props) {
         {!reputationLoading && resolveResult && !reputation && (
           <div
             className="card"
-            style={{ marginTop: '1rem', background: '#1e1b4b', border: '1px solid #334155' }}
+            style={{ marginTop: '1rem', background: 'var(--card-bg-accent)', border: '1px solid var(--border-input)' }}
           >
-            <h3 style={{ marginBottom: '0.5rem', color: '#94a3b8' }}>Reputation</h3>
-            <p style={{ color: '#64748b', fontSize: '0.85rem' }}>
+            <h3 style={{ marginBottom: '0.5rem', color: 'var(--text-muted)' }}>Reputation</h3>
+            <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>
               No reputation record found for this address.
             </p>
           </div>
@@ -156,15 +156,15 @@ export default function IdentityPanel({ wallet }: Props) {
         <h2>Anti-Sybil Check</h2>
         {resolvedAddress ? (
           <>
-            <p style={{ color: "#94a3b8", fontSize: "0.85rem", marginBottom: "1rem" }}>
-              Checking{" "}
-              <span style={{ color: "#a78bfa" }}>
+            <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem', marginBottom: '1rem' }}>
+              Checking{' '}
+              <span style={{ color: 'var(--accent-light)' }}>
                 {resolvedAddress.slice(0, 6)}…{resolvedAddress.slice(-4)}
               </span>
             </p>
-            <div style={{ display: "flex", gap: "0.75rem", marginBottom: "1rem" }}>
+            <div style={{ display: 'flex', gap: '0.75rem', marginBottom: '1rem' }}>
               <div style={{ flex: 1 }}>
-                <label style={{ display: "block", color: "#94a3b8", fontSize: "0.8rem", marginBottom: "0.25rem" }}>
+                <label style={{ display: 'block', color: 'var(--text-muted)', fontSize: '0.8rem', marginBottom: '0.25rem' }}>
                   Min Score
                 </label>
                 <input
@@ -172,11 +172,11 @@ export default function IdentityPanel({ wallet }: Props) {
                   min={0}
                   value={minScore}
                   onChange={(e) => setMinScore(e.target.value)}
-                  style={{ width: "100%" }}
+                  style={{ width: '100%' }}
                 />
               </div>
               <div style={{ flex: 1 }}>
-                <label style={{ display: "block", color: "#94a3b8", fontSize: "0.8rem", marginBottom: "0.25rem" }}>
+                <label style={{ display: 'block', color: 'var(--text-muted)', fontSize: '0.8rem', marginBottom: '0.25rem' }}>
                   Min Reporters
                 </label>
                 <input
@@ -184,32 +184,32 @@ export default function IdentityPanel({ wallet }: Props) {
                   min={1}
                   value={minReporters}
                   onChange={(e) => setMinReporters(e.target.value)}
-                  style={{ width: "100%" }}
+                  style={{ width: '100%' }}
                 />
               </div>
             </div>
             <button onClick={handleSybilCheck} disabled={checkingsSybil}>
-              {checkingsSybil ? "Checking…" : "Run Sybil Check"}
+              {checkingsSybil ? 'Checking…' : 'Run Sybil Check'}
             </button>
             {sybilResult !== null && (
               <div
                 style={{
-                  marginTop: "1rem",
-                  padding: "0.6rem 1rem",
-                  borderRadius: "0.5rem",
+                  marginTop: '1rem',
+                  padding: '0.6rem 1rem',
+                  borderRadius: '0.5rem',
                   fontWeight: 600,
-                  fontSize: "0.95rem",
-                  background: sybilResult ? "rgba(34,197,94,0.15)" : "rgba(239,68,68,0.15)",
-                  color: sybilResult ? "#4ade80" : "#f87171",
-                  border: `1px solid ${sybilResult ? "#4ade80" : "#f87171"}`,
+                  fontSize: '0.95rem',
+                  background: `var(${sybilResult ? '--sybil-pass-bg' : '--sybil-fail-bg'})`,
+                  color: `var(${sybilResult ? '--sybil-pass-text' : '--sybil-fail-text'})`,
+                  border: `1px solid var(${sybilResult ? '--sybil-pass-border' : '--sybil-fail-border'})`,
                 }}
               >
-                {sybilResult ? "✓ Passes sybil check" : "✗ Fails sybil check"}
+                {sybilResult ? '✓ Passes sybil check' : '✗ Fails sybil check'}
               </div>
             )}
           </>
         ) : (
-          <p style={{ color: "#94a3b8", fontSize: "0.85rem" }}>
+          <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>
             Resolve a DID above to run the anti-sybil check.
           </p>
         )}
@@ -219,9 +219,9 @@ export default function IdentityPanel({ wallet }: Props) {
         <h2>Create DID</h2>
         {wallet.connected && wallet.publicKey ? (
           <>
-            <p style={{ color: '#94a3b8', fontSize: '0.85rem', marginBottom: '1rem' }}>
+            <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem', marginBottom: '1rem' }}>
               Connected as{' '}
-              <span style={{ color: '#a78bfa' }}>
+              <span style={{ color: 'var(--accent-light)' }}>
                 {wallet.publicKey.slice(0, 6)}…{wallet.publicKey.slice(-4)}
               </span>
             </p>
@@ -230,7 +230,7 @@ export default function IdentityPanel({ wallet }: Props) {
             </button>
           </>
         ) : (
-          <p style={{ color: '#94a3b8', fontSize: '0.85rem' }}>
+          <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>
             Connect your Freighter wallet to create a new on-chain DID.
           </p>
         )}

--- a/frontend/src/components/WalletButton.tsx
+++ b/frontend/src/components/WalletButton.tsx
@@ -23,13 +23,13 @@ export default function WalletButton({ wallet }: Props) {
     <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: "0.25rem", position: "relative" }}>
       {connected && publicKey ? (
         <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
-          <span style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
+          <span style={{ fontSize: "0.75rem", color: "var(--text-muted)" }}>
             via {walletType === "walletconnect" ? "WalletConnect" : "Freighter"}
           </span>
           <span className="badge badge-green">{short(publicKey)}</span>
           <button
             onClick={disconnect}
-            style={{ background: "transparent", border: "1px solid #334155", color: "#94a3b8", padding: "0.3rem 0.7rem" }}
+            style={{ background: "transparent", border: "1px solid var(--border-input)", color: "var(--text-muted)", padding: "0.3rem 0.7rem" }}
           >
             Disconnect
           </button>
@@ -48,8 +48,8 @@ export default function WalletButton({ wallet }: Props) {
               position: "absolute",
               top: "calc(100% + 0.5rem)",
               right: 0,
-              background: "#1e293b",
-              border: "1px solid #334155",
+              background: "var(--dropdown-bg)",
+              border: "1px solid var(--border-input)",
               borderRadius: "0.5rem",
               padding: "0.5rem",
               display: "flex",
@@ -76,7 +76,7 @@ export default function WalletButton({ wallet }: Props) {
       )}
 
       {error && (
-        <span style={{ fontSize: "0.75rem", color: "#fca5a5" }}>{error}</span>
+        <span style={{ fontSize: "0.75rem", color: "var(--error-text)" }}>{error}</span>
       )}
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,179 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+/* ── Color tokens: light mode (default) ─────────────────────────────────────── */
+
+:root {
+  --bg:                       #f8fafc;
+  --bg-subtle:                #f1f5f9;
+  --card-bg:                  #ffffff;
+  --card-bg-accent:           #ede9fe;
+  --card-border:              #e2e8f0;
+  --card-border-accent:       #c4b5fd;
+  --dropdown-bg:              #ffffff;
+  --cred-item-bg:             #f1f5f9;
+  --text:                     #0f172a;
+  --text-muted:               #64748b;
+  --border-input:             #cbd5e1;
+  --accent:                   #7c3aed;
+  --accent-hover:             #6d28d9;
+  --accent-light:             #7c3aed;
+  --btn-disabled-bg:          #e2e8f0;
+  --btn-disabled-color:       #94a3b8;
+  --result-bg:                #f1f5f9;
+  --result-text:              #64748b;
+  --tab-border:               #cbd5e1;
+  --tab-color:                #64748b;
+  --header-border:            #e2e8f0;
+  --badge-green-bg:           #dcfce7;
+  --badge-green-text:         #166534;
+  --badge-red-bg:             #fee2e2;
+  --badge-red-text:           #991b1b;
+  --badge-purple-bg:          #ede9fe;
+  --badge-purple-text:        #5b21b6;
+  --error-text:               #dc2626;
+  --sybil-pass-bg:            rgba(34,197,94,0.15);
+  --sybil-pass-text:          #16a34a;
+  --sybil-pass-border:        #16a34a;
+  --sybil-fail-bg:            rgba(239,68,68,0.15);
+  --sybil-fail-text:          #dc2626;
+  --sybil-fail-border:        #dc2626;
+  --filter-badge-active-bg:   #7c3aed;
+  --filter-badge-active-text: #ffffff;
+}
+
+/* ── Dark mode via system preference ─────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:                       #0a0a0f;
+    --bg-subtle:                #0f172a;
+    --card-bg:                  #111827;
+    --card-bg-accent:           #1e1b4b;
+    --card-border:              #1e293b;
+    --card-border-accent:       #4c1d95;
+    --dropdown-bg:              #1e293b;
+    --cred-item-bg:             #1e293b;
+    --text:                     #e2e8f0;
+    --text-muted:               #94a3b8;
+    --border-input:             #334155;
+    --accent:                   #7c3aed;
+    --accent-hover:             #6d28d9;
+    --accent-light:             #a78bfa;
+    --btn-disabled-bg:          #374151;
+    --btn-disabled-color:       #9ca3af;
+    --result-bg:                #0f172a;
+    --result-text:              #94a3b8;
+    --tab-border:               #334155;
+    --tab-color:                #94a3b8;
+    --header-border:            #1e293b;
+    --badge-green-bg:           #064e3b;
+    --badge-green-text:         #6ee7b7;
+    --badge-red-bg:             #450a0a;
+    --badge-red-text:           #fca5a5;
+    --badge-purple-bg:          #2e1065;
+    --badge-purple-text:        #c4b5fd;
+    --error-text:               #fca5a5;
+    --sybil-pass-bg:            rgba(34,197,94,0.15);
+    --sybil-pass-text:          #4ade80;
+    --sybil-pass-border:        #4ade80;
+    --sybil-fail-bg:            rgba(239,68,68,0.15);
+    --sybil-fail-text:          #f87171;
+    --sybil-fail-border:        #f87171;
+    --filter-badge-active-bg:   #a78bfa;
+    --filter-badge-active-text: #1e1b4b;
+  }
+}
+
+/* ── Dark mode via manual class toggle ───────────────────────────────────────── */
+
+html.dark {
+  --bg:                       #0a0a0f;
+  --bg-subtle:                #0f172a;
+  --card-bg:                  #111827;
+  --card-bg-accent:           #1e1b4b;
+  --card-border:              #1e293b;
+  --card-border-accent:       #4c1d95;
+  --dropdown-bg:              #1e293b;
+  --cred-item-bg:             #1e293b;
+  --text:                     #e2e8f0;
+  --text-muted:               #94a3b8;
+  --border-input:             #334155;
+  --accent:                   #7c3aed;
+  --accent-hover:             #6d28d9;
+  --accent-light:             #a78bfa;
+  --btn-disabled-bg:          #374151;
+  --btn-disabled-color:       #9ca3af;
+  --result-bg:                #0f172a;
+  --result-text:              #94a3b8;
+  --tab-border:               #334155;
+  --tab-color:                #94a3b8;
+  --header-border:            #1e293b;
+  --badge-green-bg:           #064e3b;
+  --badge-green-text:         #6ee7b7;
+  --badge-red-bg:             #450a0a;
+  --badge-red-text:           #fca5a5;
+  --badge-purple-bg:          #2e1065;
+  --badge-purple-text:        #c4b5fd;
+  --error-text:               #fca5a5;
+  --sybil-pass-bg:            rgba(34,197,94,0.15);
+  --sybil-pass-text:          #4ade80;
+  --sybil-pass-border:        #4ade80;
+  --sybil-fail-bg:            rgba(239,68,68,0.15);
+  --sybil-fail-text:          #f87171;
+  --sybil-fail-border:        #f87171;
+  --filter-badge-active-bg:   #a78bfa;
+  --filter-badge-active-text: #1e1b4b;
+}
+
+/* ── Light mode forced via manual class toggle ───────────────────────────────── */
+
+html.light {
+  --bg:                       #f8fafc;
+  --bg-subtle:                #f1f5f9;
+  --card-bg:                  #ffffff;
+  --card-bg-accent:           #ede9fe;
+  --card-border:              #e2e8f0;
+  --card-border-accent:       #c4b5fd;
+  --dropdown-bg:              #ffffff;
+  --cred-item-bg:             #f1f5f9;
+  --text:                     #0f172a;
+  --text-muted:               #64748b;
+  --border-input:             #cbd5e1;
+  --accent:                   #7c3aed;
+  --accent-hover:             #6d28d9;
+  --accent-light:             #7c3aed;
+  --btn-disabled-bg:          #e2e8f0;
+  --btn-disabled-color:       #94a3b8;
+  --result-bg:                #f1f5f9;
+  --result-text:              #64748b;
+  --tab-border:               #cbd5e1;
+  --tab-color:                #64748b;
+  --header-border:            #e2e8f0;
+  --badge-green-bg:           #dcfce7;
+  --badge-green-text:         #166534;
+  --badge-red-bg:             #fee2e2;
+  --badge-red-text:           #991b1b;
+  --badge-purple-bg:          #ede9fe;
+  --badge-purple-text:        #5b21b6;
+  --error-text:               #dc2626;
+  --sybil-pass-bg:            rgba(34,197,94,0.15);
+  --sybil-pass-text:          #16a34a;
+  --sybil-pass-border:        #16a34a;
+  --sybil-fail-bg:            rgba(239,68,68,0.15);
+  --sybil-fail-text:          #dc2626;
+  --sybil-fail-border:        #dc2626;
+  --filter-badge-active-bg:   #7c3aed;
+  --filter-badge-active-text: #ffffff;
+}
+
+/* ── Base styles ─────────────────────────────────────────────────────────────── */
+
 body {
   font-family: system-ui, -apple-system, sans-serif;
-  background: #0a0a0f;
-  color: #e2e8f0;
+  background: var(--bg);
+  color: var(--text);
   min-height: 100vh;
+  transition: background 0.2s, color 0.2s;
 }
 
 .container { max-width: 900px; margin: 0 auto; padding: 2rem 1rem; }
@@ -12,36 +181,36 @@ body {
 header {
   text-align: center;
   padding: 3rem 0 2rem;
-  border-bottom: 1px solid #1e293b;
+  border-bottom: 1px solid var(--header-border);
   margin-bottom: 2rem;
 }
 
-header h1 { font-size: 2rem; color: #7c3aed; }
-header p  { color: #94a3b8; margin-top: 0.5rem; }
+header h1 { font-size: 2rem; color: var(--accent); }
+header p  { color: var(--text-muted); margin-top: 0.5rem; }
 
 .card {
-  background: #111827;
-  border: 1px solid #1e293b;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 12px;
   padding: 1.5rem;
   margin-bottom: 1.5rem;
 }
 
-.card h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #a78bfa; }
+.card h2 { font-size: 1.1rem; margin-bottom: 1rem; color: var(--accent-light); }
 
 input, textarea {
   width: 100%;
-  background: #0f172a;
-  border: 1px solid #334155;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border-input);
   border-radius: 8px;
   padding: 0.6rem 0.8rem;
-  color: #e2e8f0;
+  color: var(--text);
   font-size: 0.9rem;
   margin-bottom: 0.75rem;
 }
 
 button {
-  background: #7c3aed;
+  background: var(--accent);
   color: #fff;
   border: none;
   border-radius: 8px;
@@ -51,8 +220,8 @@ button {
   transition: background 0.2s;
 }
 
-button:hover  { background: #6d28d9; }
-button:disabled { background: #374151; cursor: not-allowed; }
+button:hover    { background: var(--accent-hover); }
+button:disabled { background: var(--btn-disabled-bg); color: var(--btn-disabled-color); cursor: not-allowed; }
 
 .badge {
   display: inline-block;
@@ -62,26 +231,37 @@ button:disabled { background: #374151; cursor: not-allowed; }
   font-weight: 600;
 }
 
-.badge-green  { background: #064e3b; color: #6ee7b7; }
-.badge-red    { background: #450a0a; color: #fca5a5; }
-.badge-purple { background: #2e1065; color: #c4b5fd; }
+.badge-green  { background: var(--badge-green-bg);  color: var(--badge-green-text); }
+.badge-red    { background: var(--badge-red-bg);    color: var(--badge-red-text); }
+.badge-purple { background: var(--badge-purple-bg); color: var(--badge-purple-text); }
 
 .result {
   margin-top: 1rem;
   padding: 0.75rem;
-  background: #0f172a;
+  background: var(--result-bg);
   border-radius: 8px;
   font-size: 0.8rem;
   word-break: break-all;
-  color: #94a3b8;
+  color: var(--result-text);
 }
 
 .tabs { display: flex; gap: 0.5rem; margin-bottom: 2rem; }
 .tab {
   background: transparent;
-  border: 1px solid #334155;
-  color: #94a3b8;
+  border: 1px solid var(--tab-border);
+  color: var(--tab-color);
   padding: 0.5rem 1rem;
   border-radius: 8px;
 }
-.tab.active { background: #7c3aed; border-color: #7c3aed; color: #fff; }
+.tab.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+
+.theme-toggle {
+  background: transparent;
+  border: 1px solid var(--border-input);
+  color: var(--text-muted);
+  padding: 0.3rem 0.7rem;
+  font-size: 0.85rem;
+  border-radius: 8px;
+  transition: background 0.2s, color 0.2s;
+}
+.theme-toggle:hover { background: var(--bg-subtle); color: var(--text); }


### PR DESCRIPTION
## Summary



### Frontend – Dark mode closes #23  and closes #24 

- All colours in `frontend/src/index.css` converted to CSS custom properties (`--bg`, `--text`, `--accent-light`, etc.)
- Light-mode token set is the default; `@media (prefers-color-scheme: dark)` applies dark tokens automatically based on OS preference
- `html.dark` / `html.light` class overrides allow manual toggling independent of the system setting
- `useDarkMode` hook in `App.tsx` initialises from `localStorage` (falling back to the system preference), applies the class to `<html>`, and persists the choice on every toggle
- `☾ Dark` / `☀ Light` toggle button added to the app header (alongside the existing wallet button)
- Every hardcoded hex colour in `IdentityPanel.tsx`, `CredentialsPanel.tsx`, and `WalletButton.tsx` replaced with the corresponding `var(--…)` reference — no hardcoded colour values remain in component files

### Reputation contract – unit tests closes #25 

Pre-existing compile errors fixed (`filter`/`collect` on `soroban_sdk::Vec`, `into_bytes()` on `soroban_sdk::String`). Four new tests added (7 total, all passing):

| Test | Covers |
|---|---|
| `test_score_accumulation` *(existing)* | `submit_score` increments score |
| `test_get_history_pagination` *(existing)* | `get_history` pagination |
| `test_sybil_check` *(existing)* | `passes_sybil_check` basic pass/fail |
| `test_submit_score_unauthorized_reporter` 🆕 | Panics for unregistered reporter |
| `test_sybil_check_score_threshold` 🆕 | Returns `false` when score < `min_score` |
| `test_sybil_check_no_record` 🆕 | Returns `false` for subject with no history |
| `test_get_history_per_reporter` 🆕 | History scoped correctly per reporter |

### Credential-manager contract – unit tests closes #28 
Pre-existing compile errors fixed (invalid `&Env`/`&Address` in public contract function, `into_bytes()`, missing `.into()` on `sha256`, wrong `extend_from_slice` argument type). Four new tests added (6 total, all passing):

| Test | Covers |
|---|---|
| `test_issue_and_verify` *(existing)* | `issue_credential` + `verify_credential` valid |
| `test_revoke_credential` *(existing)* | `revoke_credential` → `verify_credential` false |
| `test_issue_unauthorized_issuer` 🆕 | Panics for unregistered issuer |
| `test_verify_expired_credential` 🆕 | Returns `false` after `expires_at` (ledger time advanced) |
| `test_revoke_by_different_issuer` 🆕 | Panics when non-issuer attempts revoke |
| `test_credential_stored_correctly` 🆕 | `get_credential` returns all fields as issued |

## Test plan

- [x] `cargo test` in `contracts/reputation` → **7 passed, 0 failed**
- [x] `cargo test` in `contracts/credential-manager` → **6 passed, 0 failed**
- [x] Dark/light toggle button visible in header
- [x] Theme persists across page reloads (localStorage)
- [x] `@media (prefers-color-scheme: dark)` applies without JS interaction
- [x] No hardcoded colour values remain in component `.tsx` files

