### PR TITLE
feat: resolve issues #59 #60 #61 #62

### DIFF
--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -12,6 +12,16 @@ const ISSUER: Symbol = symbol_short!("ISSUER");
 const CRED: Symbol = symbol_short!("CRED");
 const IDSEQ: Symbol = symbol_short!("IDSEQ");
 
+const MAX_CREDENTIALS_PER_TYPE_PER_ISSUER: u32 = 5;
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ContractError {
+    CredentialLimitExceeded,
+}
+
 // ── Data types ────────────────────────────────────────────────────────────────
 
 /// Credential types supported by the protocol.
@@ -103,14 +113,34 @@ impl CredentialManager {
         issuer.require_auth();
         Self::require_issuer(&env, &issuer);
 
+        // Enforce per-issuer-per-type-per-subject limit
+        let type_key = Self::issuer_type_key(&issuer, &subject, &credential_type);
+        let existing: Vec<BytesN<32>> = env
+            .storage()
+            .persistent()
+            .get(&type_key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        // Count only active (non-revoked, non-expired) credentials
         let now = env.ledger().timestamp();
+        let active_count = existing.iter().filter(|id| {
+            match env.storage().persistent().get::<(Symbol, BytesN<32>), Credential>(&Self::cred_key(id)) {
+                None => false,
+                Some(c) => !c.revoked && (c.expires_at == 0 || c.expires_at > now),
+            }
+        }).count() as u32;
+
+        if active_count >= MAX_CREDENTIALS_PER_TYPE_PER_ISSUER {
+            panic!("CredentialLimitExceeded");
+        }
+
         let id = Self::generate_id(&env, now);
 
         let credential = Credential {
             id: id.clone(),
             subject: subject.clone(),
             issuer: issuer.clone(),
-            credential_type,
+            credential_type: credential_type.clone(),
             claims,
             signature,
             issued_at: now,
@@ -126,6 +156,11 @@ impl CredentialManager {
         subject_creds.push_back(id.clone());
         let subject_key = Self::subject_key(&subject);
         env.storage().persistent().set(&subject_key, &subject_creds);
+
+        // Index credential under issuer+subject+type
+        let mut type_creds = existing;
+        type_creds.push_back(id.clone());
+        env.storage().persistent().set(&type_key, &type_creds);
 
         env.events().publish((CRED, symbol_short!("issued")), (issuer, subject));
 
@@ -230,6 +265,10 @@ impl CredentialManager {
 
     fn subject_key(subject: &Address) -> (Symbol, Address) {
         (symbol_short!("sub"), subject.clone())
+    }
+
+    fn issuer_type_key(issuer: &Address, subject: &Address, credential_type: &CredentialType) -> (Symbol, Address, Address, CredentialType) {
+        (symbol_short!("it"), issuer.clone(), subject.clone(), credential_type.clone())
     }
 }
 

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -15,6 +15,7 @@ use soroban_sdk::{
 
 const ADMIN: Symbol    = symbol_short!("ADMIN");
 const REPORTER: Symbol = symbol_short!("REPORTER");
+const DEF_THRESH: Symbol = symbol_short!("DEFTHRESH");
 
 // ── Data types ────────────────────────────────────────────────────────────────
 
@@ -29,6 +30,14 @@ pub struct ReputationRecord {
     pub reporter_count: u32,
     /// Last update timestamp
     pub updated_at: u64,
+}
+
+/// Stored default sybil threshold set by the admin.
+#[contracttype]
+#[derive(Clone)]
+pub struct DefaultThreshold {
+    pub min_score: i64,
+    pub min_reporters: u32,
 }
 
 /// A single score submission from a reporter.
@@ -76,6 +85,26 @@ impl Reputation {
             }
         }
         env.storage().instance().set(&REPORTER, &updated);
+    }
+
+    /// Set the default sybil threshold (admin only).
+    pub fn set_default_threshold(env: Env, min_score: i64, min_reporters: u32) {
+        Self::require_admin(&env);
+        env.storage().instance().set(&DEF_THRESH, &DefaultThreshold { min_score, min_reporters });
+    }
+
+    /// Anti-sybil check using the stored default threshold.
+    pub fn passes_sybil_check_default(env: Env, subject: Address) -> bool {
+        let threshold: DefaultThreshold = env
+            .storage()
+            .instance()
+            .get(&DEF_THRESH)
+            .expect("default threshold not set");
+        let key = Self::record_key(&subject);
+        match env.storage().persistent().get::<(Symbol, Address), ReputationRecord>(&key) {
+            None => false,
+            Some(rec) => rec.score >= threshold.min_score && rec.reporter_count >= threshold.min_reporters,
+        }
     }
 
     // ── Scoring ───────────────────────────────────────────────────────────────

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -7,7 +7,8 @@ import {
   nativeToScVal,
   scValToNative,
 } from "@stellar/stellar-sdk";
-import type { Credential, CredentialType, SorobanIdentityConfig, VerifyResult } from "./types";
+import type { CallOptions, Credential, CredentialType, SorobanIdentityConfig, VerifyResult } from "./types";
+import { retryWithBackoff } from "./utils";
 
 export class CredentialClient {
   private server: SorobanRpc.Server;
@@ -28,9 +29,11 @@ export class CredentialClient {
     subjectAddress: string,
     credentialType: CredentialType,
     claims: Record<string, string>,
-    expiresAt = 0
+    expiresAt = 0,
+    options?: CallOptions
   ): Promise<string> {
     const account = await this.server.getAccount(issuerKeypair.publicKey());
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     // Signature is over SHA256(issuer + subject + claims) — simplified here
     const signature = issuerKeypair.sign(
@@ -52,13 +55,13 @@ export class CredentialClient {
           nativeToScVal(expiresAt, { type: "u64" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const prepared = await this.server.prepareTransaction(tx);
+    const prepared = await retryWithBackoff(() => this.server.prepareTransaction(tx));
     prepared.sign(issuerKeypair);
 
-    const result = await this.server.sendTransaction(prepared);
+    const result = await retryWithBackoff(() => this.server.sendTransaction(prepared));
     if (result.status !== "PENDING") {
       throw new Error(`Transaction failed: ${result.status}`);
     }
@@ -75,10 +78,12 @@ export class CredentialClient {
    */
   async verifyCredential(
     callerAddress: string,
-    credentialId: string
+    credentialId: string,
+    options?: CallOptions
   ): Promise<VerifyResult> {
     const account = await this.server.getAccount(callerAddress);
     const idBytes = Buffer.from(credentialId, "hex");
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -90,10 +95,10 @@ export class CredentialClient {
           nativeToScVal(idBytes, { type: "bytes" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const result = await this.server.simulateTransaction(tx);
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
 
     if (SorobanRpc.Api.isSimulationError(result)) {
       const error: string = (result as { error: string }).error ?? "";
@@ -130,11 +135,12 @@ export class CredentialClient {
    */
   async getCredentialsBySubject(
     callerAddress: string,
-    subjectAddress: string
+    subjectAddress: string,
+    options?: CallOptions
   ): Promise<Credential[]> {
     const account = await this.server.getAccount(callerAddress);
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
-    // Fetch the list of credential IDs for the subject
     const idsTx = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase: this.config.networkPassphrase,
@@ -145,10 +151,10 @@ export class CredentialClient {
           nativeToScVal(subjectAddress, { type: "address" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const idsResult = await this.server.simulateTransaction(idsTx);
+    const idsResult = await retryWithBackoff(() => this.server.simulateTransaction(idsTx));
     if (SorobanRpc.Api.isSimulationError(idsResult)) {
       throw new Error(`Simulation failed: ${idsResult.error}`);
     }
@@ -160,59 +166,11 @@ export class CredentialClient {
 
     if (!ids || ids.length === 0) return [];
 
-    // Resolve each credential by ID
-    const credentials = await Promise.all(
+    return Promise.all(
       ids.map((raw) =>
-        this.getCredential(callerAddress, Buffer.from(raw).toString("hex"))
+        this.getCredential(callerAddress, Buffer.from(raw).toString("hex"), options)
       )
     );
-
-    return credentials;
-  }
-
-  /**
-   * Get all credentials issued to a subject address.
-   */
-  async getCredentialsBySubject(
-    callerAddress: string,
-    subjectAddress: string
-  ): Promise<Credential[]> {
-    const account = await this.server.getAccount(callerAddress);
-
-    // Fetch the list of credential IDs for the subject
-    const idsTx = new TransactionBuilder(account, {
-      fee: BASE_FEE,
-      networkPassphrase: this.config.networkPassphrase,
-    })
-      .addOperation(
-        this.contract.call(
-          "get_subject_credentials",
-          nativeToScVal(subjectAddress, { type: "address" })
-        )
-      )
-      .setTimeout(this.config.txTimeout ?? 30)
-      .build();
-
-    const idsResult = await this.server.simulateTransaction(idsTx);
-    if (SorobanRpc.Api.isSimulationError(idsResult)) {
-      throw new Error(`Simulation failed: ${idsResult.error}`);
-    }
-
-    const ids = scValToNative(
-      (idsResult as SorobanRpc.Api.SimulateTransactionSuccessResponse)
-        .result!.retval
-    ) as Uint8Array[];
-
-    if (!ids || ids.length === 0) return [];
-
-    // Resolve each credential by ID
-    const credentials = await Promise.all(
-      ids.map((raw) =>
-        this.getCredential(callerAddress, Buffer.from(raw).toString("hex"))
-      )
-    );
-
-    return credentials;
   }
 
   /**
@@ -220,10 +178,12 @@ export class CredentialClient {
    */
   async getCredential(
     callerAddress: string,
-    credentialId: string
+    credentialId: string,
+    options?: CallOptions
   ): Promise<Credential> {
     const account = await this.server.getAccount(callerAddress);
     const idBytes = Buffer.from(credentialId, "hex");
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -235,10 +195,10 @@ export class CredentialClient {
           nativeToScVal(idBytes, { type: "bytes" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const result = await this.server.simulateTransaction(tx);
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
     if (SorobanRpc.Api.isSimulationError(result)) {
       throw new Error(`Simulation failed: ${result.error}`);
     }

--- a/sdk/src/identity.ts
+++ b/sdk/src/identity.ts
@@ -7,7 +7,8 @@ import {
   nativeToScVal,
   scValToNative,
 } from "@stellar/stellar-sdk";
-import type { DidDocument, SorobanIdentityConfig } from "./types";
+import type { CallOptions, DidDocument, SorobanIdentityConfig } from "./types";
+import { retryWithBackoff } from "./utils";
 
 export class IdentityClient {
   private server: SorobanRpc.Server;
@@ -25,11 +26,13 @@ export class IdentityClient {
    */
   async createDid(
     keypair: Keypair,
-    metadata: Record<string, string> = {}
+    metadata: Record<string, string> = {},
+    options?: CallOptions
   ): Promise<string> {
     const account = await this.server.getAccount(keypair.publicKey());
 
     const metaScVal = nativeToScVal(metadata, { type: "map" });
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -42,13 +45,13 @@ export class IdentityClient {
           metaScVal
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const prepared = await this.server.prepareTransaction(tx);
+    const prepared = await retryWithBackoff(() => this.server.prepareTransaction(tx));
     prepared.sign(keypair);
 
-    const result = await this.server.sendTransaction(prepared);
+    const result = await retryWithBackoff(() => this.server.sendTransaction(prepared));
     if (result.status !== "PENDING") {
       throw new Error(`Transaction failed: ${result.status}`);
     }
@@ -73,9 +76,11 @@ export class IdentityClient {
    */
   async updateDid(
     keypair: Keypair,
-    metadata: Record<string, string>
+    metadata: Record<string, string>,
+    options?: CallOptions
   ): Promise<void> {
     const account = await this.server.getAccount(keypair.publicKey());
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -88,13 +93,13 @@ export class IdentityClient {
           nativeToScVal(metadata, { type: "map" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const prepared = await this.server.prepareTransaction(tx);
+    const prepared = await retryWithBackoff(() => this.server.prepareTransaction(tx));
     prepared.sign(keypair);
 
-    const result = await this.server.sendTransaction(prepared);
+    const result = await retryWithBackoff(() => this.server.sendTransaction(prepared));
     if (result.status !== "PENDING") {
       throw new Error(`Transaction failed: ${result.status}`);
     }
@@ -120,8 +125,9 @@ export class IdentityClient {
   /**
    * Resolve a DID document by controller address.
    */
-  async resolveDid(controllerAddress: string): Promise<DidDocument> {
+  async resolveDid(controllerAddress: string, options?: CallOptions): Promise<DidDocument> {
     const account = await this.server.getAccount(controllerAddress);
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -133,10 +139,10 @@ export class IdentityClient {
           nativeToScVal(controllerAddress, { type: "address" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const result = await this.server.simulateTransaction(tx);
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
     if (SorobanRpc.Api.isSimulationError(result)) {
       throw new Error(`Simulation failed: ${result.error}`);
     }
@@ -150,8 +156,9 @@ export class IdentityClient {
   /**
    * Check if an address has an active DID.
    */
-  async hasActiveDid(controllerAddress: string): Promise<boolean> {
+  async hasActiveDid(controllerAddress: string, options?: CallOptions): Promise<boolean> {
     const account = await this.server.getAccount(controllerAddress);
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -163,10 +170,10 @@ export class IdentityClient {
           nativeToScVal(controllerAddress, { type: "address" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const result = await this.server.simulateTransaction(tx);
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
     if (SorobanRpc.Api.isSimulationError(result)) return false;
 
     return scValToNative(

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,15 +1,18 @@
 export { IdentityClient } from "./identity";
 export { CredentialClient } from "./credentials";
 export { ReputationClient } from "./reputation";
+export { retryWithBackoff } from "./utils";
 export type {
   DidDocument,
   Credential,
   CredentialType,
   VerifyResult,
   VerifyFailReason,
-  SorobanIdentityConfig,
+  CallOptions,
 } from "./types";
 export type { ReputationRecord, ScoreHistoryEntry } from "./reputation";
+import type { SorobanIdentityConfig } from "./types";
+export type { SorobanIdentityConfig };
 
 // Testnet defaults — fill contract IDs after deployment
 export const TESTNET_CONFIG: SorobanIdentityConfig = {

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -7,7 +7,8 @@ import {
   nativeToScVal,
   scValToNative,
 } from "@stellar/stellar-sdk";
-import type { SorobanIdentityConfig } from "./types";
+import type { CallOptions, SorobanIdentityConfig } from "./types";
+import { retryWithBackoff } from "./utils";
 
 export interface ReputationRecord {
   subject: string;
@@ -35,8 +36,9 @@ export class ReputationClient {
   }
 
   /** Get the reputation record for a subject. */
-  async getReputation(callerAddress: string, subjectAddress: string): Promise<ReputationRecord> {
+  async getReputation(callerAddress: string, subjectAddress: string, options?: CallOptions): Promise<ReputationRecord> {
     const account = await this.server.getAccount(callerAddress);
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -48,10 +50,10 @@ export class ReputationClient {
           nativeToScVal(subjectAddress, { type: "address" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const result = await this.server.simulateTransaction(tx);
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
     if (SorobanRpc.Api.isSimulationError(result)) {
       throw new Error(`Simulation failed: ${result.error}`);
     }
@@ -75,9 +77,11 @@ export class ReputationClient {
     subjectAddress: string,
     reporterAddress: string,
     offset = 0,
-    limit = 20
+    limit = 20,
+    options?: CallOptions
   ): Promise<ScoreHistoryEntry[]> {
     const account = await this.server.getAccount(callerAddress);
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -92,10 +96,10 @@ export class ReputationClient {
           nativeToScVal(limit, { type: "u32" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const result = await this.server.simulateTransaction(tx);
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
     if (SorobanRpc.Api.isSimulationError(result)) {
       throw new Error(`Simulation failed: ${result.error}`);
     }
@@ -105,14 +109,46 @@ export class ReputationClient {
     ) as ScoreHistoryEntry[];
   }
 
+  /** Check if a subject passes the sybil threshold using the contract's stored default. */
+  async passesSybilCheckDefault(
+    callerAddress: string,
+    subjectAddress: string,
+    options?: CallOptions
+  ): Promise<boolean> {
+    const account = await this.server.getAccount(callerAddress);
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          "passes_sybil_check_default",
+          nativeToScVal(subjectAddress, { type: "address" })
+        )
+      )
+      .setTimeout(timeout)
+      .build();
+
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
+    if (SorobanRpc.Api.isSimulationError(result)) return false;
+
+    return scValToNative(
+      (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval
+    ) as boolean;
+  }
+
   /** Check if a subject passes the sybil threshold. */
   async passesSybilCheck(
     callerAddress: string,
     subjectAddress: string,
     minScore: number,
-    minReporters: number
+    minReporters: number,
+    options?: CallOptions
   ): Promise<boolean> {
     const account = await this.server.getAccount(callerAddress);
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -126,10 +162,10 @@ export class ReputationClient {
           nativeToScVal(minReporters, { type: "u32" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const result = await this.server.simulateTransaction(tx);
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
     if (SorobanRpc.Api.isSimulationError(result)) return false;
 
     return scValToNative(
@@ -142,9 +178,11 @@ export class ReputationClient {
     reporterKeypair: Keypair,
     subjectAddress: string,
     delta: number,
-    reason: string
+    reason: string,
+    options?: CallOptions
   ): Promise<void> {
     const account = await this.server.getAccount(reporterKeypair.publicKey());
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -159,13 +197,13 @@ export class ReputationClient {
           nativeToScVal(reason, { type: "string" })
         )
       )
-      .setTimeout(this.config.txTimeout ?? 30)
+      .setTimeout(timeout)
       .build();
 
-    const prepared = await this.server.prepareTransaction(tx);
+    const prepared = await retryWithBackoff(() => this.server.prepareTransaction(tx));
     prepared.sign(reporterKeypair);
 
-    const result = await this.server.sendTransaction(prepared);
+    const result = await retryWithBackoff(() => this.server.sendTransaction(prepared));
     if (result.status !== "PENDING") {
       throw new Error(`Transaction failed: ${result.status}`);
     }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -36,3 +36,9 @@ export interface SorobanIdentityConfig {
   /** Transaction timeout in seconds. Defaults to 30. */
   txTimeout?: number;
 }
+
+/** Per-call options that override the global config. */
+export interface CallOptions {
+  /** Override transaction timeout in seconds for this call only. */
+  timeoutSeconds?: number;
+}

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Retries an async function with exponential backoff on transient network errors.
+ * Contract-level errors (non-network) are NOT retried.
+ *
+ * @param fn          - Async function to execute.
+ * @param maxRetries  - Maximum number of retry attempts (default: 3).
+ * @param baseDelayMs - Initial delay in ms, doubles each retry (default: 500).
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  maxRetries = 3,
+  baseDelayMs = 500
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err: unknown) {
+      if (!isTransientError(err) || attempt === maxRetries) throw err;
+      lastError = err;
+      await delay(baseDelayMs * 2 ** attempt);
+    }
+  }
+  throw lastError;
+}
+
+function isTransientError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("503") ||
+    msg.includes("timeout") ||
+    msg.includes("network") ||
+    msg.includes("econnreset") ||
+    msg.includes("econnrefused") ||
+    msg.includes("fetch failed")
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => (globalThis as unknown as { setTimeout: (fn: () => void, ms: number) => void }).setTimeout(resolve, ms));
+}


### PR DESCRIPTION
- #59: Add CallOptions interface; all SDK client methods accept optional per-call timeoutSeconds override on top of the global txTimeout config

- #61: Add retryWithBackoff utility (3 retries, 500ms base, exponential) in sdk/src/utils.ts; wrap all simulateTransaction/prepareTransaction/ sendTransaction calls in IdentityClient, CredentialClient, ReputationClient; export retryWithBackoff and CallOptions from index.ts

- #60: Add DefaultThreshold struct and DEF_THRESH storage key to reputation contract; add set_default_threshold(admin, min_score, min_reporters) and passes_sybil_check_default(subject); add passesSybilCheckDefault to SDK

- #62: Add MAX_CREDENTIALS_PER_TYPE_PER_ISSUER=5 constant and ContractError::CredentialLimitExceeded to credential-manager; enforce limit in issue_credential by counting active credentials of same issuer+type per subject; index credentials under issuer+subject+type key

Also fixes pre-existing duplicate getCredentialsBySubject method and SorobanIdentityConfig type export error in index.ts.

Closes #59 
Closes #60 
Closes #61 
Closes #62 