### PR TITLE
fix: resolve 4 security/correctness bugs across identity, credential, and reputation contracts

### DIFF
--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -20,6 +20,7 @@ const MAX_CREDENTIALS_PER_TYPE_PER_ISSUER: u32 = 5;
 #[derive(Clone, Debug, PartialEq)]
 pub enum ContractError {
     CredentialLimitExceeded,
+    CredentialAlreadyExpired,
 }
 
 // ── Data types ────────────────────────────────────────────────────────────────
@@ -132,6 +133,10 @@ impl CredentialManager {
 
         if active_count >= MAX_CREDENTIALS_PER_TYPE_PER_ISSUER {
             panic!("CredentialLimitExceeded");
+        }
+
+        if expires_at != 0 && expires_at <= now {
+            panic!("CredentialAlreadyExpired");
         }
 
         let id = Self::generate_id(&env, now);
@@ -333,7 +338,27 @@ mod tests {
         assert!(!client.verify_credential(&cred_id));
     }
 
-    /// issue_credential must panic when the caller is not a registered issuer.
+    /// issue_credential must panic when expires_at is in the past.
+    #[test]
+    #[should_panic]
+    fn test_issue_credential_already_expired() {
+        let (env, _admin, client) = setup();
+
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.add_issuer(&issuer);
+
+        let claims: Map<String, String> = Map::new(&env);
+        let sig = Bytes::from_array(&env, &[0u8; 64]);
+        // expires_at is in the past (timestamp 1 is before the default ledger time)
+        let past_expiry = env.ledger().timestamp().saturating_sub(1);
+
+        client.issue_credential(
+            &issuer, &subject, &CredentialType::Kyc, &claims, &sig, &past_expiry,
+        );
+    }
+
+    /// issue_credential must panic when called by an address that did not issue the credential.
     #[test]
     #[should_panic]
     fn test_issue_unauthorized_issuer() {

--- a/contracts/identity-registry/src/lib.rs
+++ b/contracts/identity-registry/src/lib.rs
@@ -1,9 +1,19 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short,
+    contract, contractimpl, contracttype, contracterror, symbol_short,
     Address, Bytes, Env, Map, String, Symbol,
 };
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ContractError {
+    DidNotFound    = 1,
+    DidDeactivated = 2,
+    MetadataTooLong = 3,
+}
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
@@ -50,7 +60,7 @@ impl IdentityRegistry {
     // ── DID management ────────────────────────────────────────────────────────
 
     /// Create a new DID for the caller.
-    pub fn create_did(env: Env, controller: Address, metadata: Map<String, String>) -> String {
+    pub fn create_did(env: Env, controller: Address, metadata: Map<String, String>) -> Result<String, ContractError> {
         controller.require_auth();
 
         let storage = env.storage().persistent();
@@ -59,6 +69,8 @@ impl IdentityRegistry {
         if storage.has(&key) {
             panic!("DID already exists for this address");
         }
+
+        Self::validate_metadata(&metadata)?;
 
         let did_id = Self::build_did_id(&env, &controller);
         let now = env.ledger().timestamp();
@@ -75,12 +87,14 @@ impl IdentityRegistry {
         storage.set(&key, &doc);
         env.events().publish((IDENTITY, symbol_short!("created")), controller);
 
-        did_id
+        Ok(did_id)
     }
 
     /// Update metadata on an existing DID.
-    pub fn update_did(env: Env, controller: Address, metadata: Map<String, String>) {
+    pub fn update_did(env: Env, controller: Address, metadata: Map<String, String>) -> Result<(), ContractError> {
         controller.require_auth();
+
+        Self::validate_metadata(&metadata)?;
 
         let storage = env.storage().persistent();
         let key = Self::did_key(&env, &controller);
@@ -91,6 +105,7 @@ impl IdentityRegistry {
 
         storage.set(&key, &doc);
         env.events().publish((IDENTITY, symbol_short!("updated")), controller);
+        Ok(())
     }
 
     /// Deactivate a DID (soft delete).
@@ -109,12 +124,16 @@ impl IdentityRegistry {
     }
 
     /// Resolve a DID document by controller address.
-    pub fn resolve_did(env: Env, controller: Address) -> DidDocument {
+    pub fn resolve_did(env: Env, controller: Address) -> Result<DidDocument, ContractError> {
         let key = Self::did_key(&env, &controller);
-        env.storage()
+        let doc: DidDocument = env.storage()
             .persistent()
             .get(&key)
-            .expect("DID not found")
+            .ok_or(ContractError::DidNotFound)?;
+        if !doc.active {
+            return Err(ContractError::DidDeactivated);
+        }
+        Ok(doc)
     }
 
     /// Check whether an address has an active DID.
@@ -127,6 +146,15 @@ impl IdentityRegistry {
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn validate_metadata(metadata: &Map<String, String>) -> Result<(), ContractError> {
+        for (k, v) in metadata.iter() {
+            if k.len() > 64 || v.len() > 256 {
+                return Err(ContractError::MetadataTooLong);
+            }
+        }
+        Ok(())
+    }
 
     fn did_key(env: &Env, controller: &Address) -> Bytes {
         // Use the raw address bytes as the storage key
@@ -196,5 +224,93 @@ mod tests {
         assert!(client.has_active_did(&user));
         client.deactivate_did(&user);
         assert!(!client.has_active_did(&user));
+    }
+
+    /// resolve_did on a deactivated DID must return DidDeactivated error.
+    #[test]
+    fn test_resolve_deactivated_did_returns_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, IdentityRegistry);
+        let client = IdentityRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let user = Address::generate(&env);
+        client.create_did(&user, &Map::new(&env));
+        client.deactivate_did(&user);
+
+        let result = client.try_resolve_did(&user);
+        assert_eq!(result, Err(Ok(ContractError::DidDeactivated)));
+    }
+
+    /// resolve_did on a non-existent DID must return DidNotFound error.
+    #[test]
+    fn test_resolve_nonexistent_did_returns_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, IdentityRegistry);
+        let client = IdentityRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let user = Address::generate(&env);
+        let result = client.try_resolve_did(&user);
+        assert_eq!(result, Err(Ok(ContractError::DidNotFound)));
+    }
+
+    /// create_did must return MetadataTooLong when a key exceeds 64 chars.
+    #[test]
+    fn test_create_did_metadata_key_too_long() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, IdentityRegistry);
+        let client = IdentityRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let user = Address::generate(&env);
+        let mut metadata: Map<String, String> = Map::new(&env);
+        // 65-character key
+        metadata.set(
+            String::from_str(&env, "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeefffff1234567890"),
+            String::from_str(&env, "value"),
+        );
+
+        let result = client.try_create_did(&user, &metadata);
+        assert_eq!(result, Err(Ok(ContractError::MetadataTooLong)));
+    }
+
+    /// update_did must return MetadataTooLong when a value exceeds 256 chars.
+    #[test]
+    fn test_update_did_metadata_value_too_long() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, IdentityRegistry);
+        let client = IdentityRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let user = Address::generate(&env);
+        client.create_did(&user, &Map::new(&env));
+
+        let mut metadata: Map<String, String> = Map::new(&env);
+        // 257-character value
+        let long_val = "a".repeat(257);
+        metadata.set(
+            String::from_str(&env, "key"),
+            String::from_str(&env, &long_val),
+        );
+
+        let result = client.try_update_did(&user, &metadata);
+        assert_eq!(result, Err(Ok(ContractError::MetadataTooLong)));
     }
 }

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -135,7 +135,7 @@ impl Reputation {
                 updated_at: now,
             });
 
-        record.score = record.score.saturating_add(delta);
+        record.score = record.score.saturating_add(delta).max(0);
         record.updated_at = now;
 
         // Track whether this reporter is new for this subject
@@ -415,6 +415,29 @@ mod tests {
         let subject = Address::generate(&env); // no history
         // Even with zero thresholds the contract returns false when no record exists
         assert!(!client.passes_sybil_check(&subject, &0, &0));
+    }
+
+    /// Score must never go below 0 regardless of negative deltas.
+    #[test]
+    fn test_score_floor_at_zero() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, Reputation);
+        let client = ReputationClient::new(&env, &contract_id);
+
+        let admin    = Address::generate(&env);
+        let reporter = Address::generate(&env);
+        let subject  = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.add_reporter(&reporter);
+
+        let reason = String::from_str(&env, "penalty");
+        client.submit_score(&reporter, &subject, &-9_999_999, &reason);
+
+        let rec = client.get_reputation(&subject);
+        assert_eq!(rec.score, 0);
     }
 
     /// get_history returns only entries submitted by the specified reporter.

--- a/sdk/src/identity.ts
+++ b/sdk/src/identity.ts
@@ -144,7 +144,14 @@ export class IdentityClient {
 
     const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
     if (SorobanRpc.Api.isSimulationError(result)) {
-      throw new Error(`Simulation failed: ${result.error}`);
+      const errMsg = result.error ?? "";
+      if (errMsg.includes("DidDeactivated")) {
+        throw new Error(`DID for address ${controllerAddress} has been deactivated.`);
+      }
+      if (errMsg.includes("DidNotFound")) {
+        throw new Error(`No DID found for address ${controllerAddress}.`);
+      }
+      throw new Error(`Simulation failed: ${errMsg}`);
     }
 
     return scValToNative(


### PR DESCRIPTION
## Summary

This PR fixes four bugs identified across the Soroban Identity smart contracts and TypeScript SDK.
closes #47 closes #48 closes #49 closes #50
---

## Fixes

### 1. `reputation`: Clamp score to 0 minimum in `submit_score`

**Problem:** A reporter could submit a large negative delta (e.g. `-9_999_999`) to drive a subject's score to `i64::MIN`, causing integer overflow risk and permanently failing `passes_sybil_check` for legitimate users.

**Fix:** After applying the delta with `saturating_add`, clamp the result to `0` using `.max(0)`.

```rust
// Before
record.score = record.score.saturating_add(delta);

// After
record.score = record.score.saturating_add(delta).max(0);
```

**Test added:** `test_score_floor_at_zero`

---

### 2. `identity-registry`: `resolve_did` returns typed error instead of panicking

**Problem:** `resolve_did` called `.expect("DID not found")` which panicked for both missing and deactivated DIDs, producing an opaque transaction failure.

**Fix:**
- Added `ContractError` enum with `DidNotFound = 1` and `DidDeactivated = 2` variants
- `resolve_did` now returns `Result<DidDocument, ContractError>`
- SDK `IdentityClient.resolveDid` surfaces both errors with descriptive messages

**Tests added:** `test_resolve_deactivated_did_returns_error`, `test_resolve_nonexistent_did_returns_error`

---

### 3. `credential-manager`: Reject past `expires_at` in `issue_credential`

**Problem:** `issue_credential` accepted past timestamps, allowing credentials that immediately fail `verify_credential`.

**Fix:** Assert `expires_at > now` when `expires_at != 0`; panic with `CredentialAlreadyExpired` otherwise.

**Test added:** `test_issue_credential_already_expired`

---

### 4. `identity-registry`: Validate metadata key/value lengths

**Problem:** No length validation on metadata allowed unbounded ledger storage bloat.

**Fix:** Added `MetadataTooLong = 3` error and `validate_metadata` helper enforcing key ≤ 64 chars, value ≤ 256 chars in both `create_did` and `update_did`.

**Tests added:** `test_create_did_metadata_key_too_long`, `test_update_did_metadata_value_too_long`

---

## Files Changed

| File | Change |
|---|---|
| `contracts/reputation/src/lib.rs` | Score floor clamp + test |
| `contracts/identity-registry/src/lib.rs` | ContractError enum, resolve_did Result return, metadata validation + tests |
| `contracts/credential-manager/src/lib.rs` | CredentialAlreadyExpired variant, expires_at check + test |
| `sdk/src/identity.ts` | resolveDid surfaces DidDeactivated / DidNotFound errors |

## Checklist

- [x] Each fix is a separate commit
- [x] Unit tests added for every fix
- [x] No `.unwrap()`/`.expect()` remain in fixed functions
- [x] SDK surfaces new contract errors with descriptive messages