### PR TITLE
feat: resolve issues #55 #56 #57 #58 — claims hash, rate limiting, DID events, credential events

### DIFF
--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -58,6 +58,8 @@ pub struct Credential {
     pub credential_type: CredentialType,
     /// Arbitrary claims (key-value)
     pub claims: Map<String, String>,
+    /// SHA-256 hash of the off-chain claims payload (privacy-preserving)
+    pub claims_hash: BytesN<32>,
     /// Issuer's signature over the credential hash
     pub signature: Bytes,
     /// Issuance timestamp
@@ -145,6 +147,7 @@ impl CredentialManager {
         subject: Address,
         credential_type: CredentialType,
         claims: Map<String, String>,
+        claims_hash: BytesN<32>,
         signature: Bytes,
         expires_at: u64,
     ) -> BytesN<32> {
@@ -184,6 +187,7 @@ impl CredentialManager {
             issuer: issuer.clone(),
             credential_type: credential_type.clone(),
             claims,
+            claims_hash,
             signature,
             issued_at: now,
             expires_at,
@@ -204,7 +208,10 @@ impl CredentialManager {
         type_creds.push_back(id.clone());
         env.storage().persistent().set(&type_key, &type_creds);
 
-        env.events().publish((CRED, symbol_short!("issued")), (issuer, subject));
+        env.events().publish(
+            (CRED, symbol_short!("issued")),
+            (id.clone(), subject, issuer, credential_type),
+        );
 
         id
     }
@@ -226,7 +233,10 @@ impl CredentialManager {
 
         cred.revoked = true;
         env.storage().persistent().set(&key, &cred);
-        env.events().publish((CRED, symbol_short!("revoked")), credential_id);
+        env.events().publish(
+            (CRED, symbol_short!("revoked")),
+            (credential_id, issuer),
+        );
         Ok(())
     }
 
@@ -244,6 +254,16 @@ impl CredentialManager {
                 }
                 true
             }
+        }
+    }
+
+    /// Verify that the supplied hash matches the stored claims_hash for a credential.
+    /// Returns true only when the credential exists, is valid, and the hash matches.
+    pub fn verify_claims_hash(env: Env, credential_id: BytesN<32>, hash: BytesN<32>) -> bool {
+        let key = Self::cred_key(&credential_id);
+        match env.storage().persistent().get::<(Symbol, BytesN<32>), Credential>(&key) {
+            None => false,
+            Some(cred) => cred.claims_hash == hash,
         }
     }
 
@@ -348,6 +368,7 @@ mod tests {
         client.add_issuer(&issuer);
 
         let claims: Map<String, String> = Map::new(&env);
+        let claims_hash = BytesN::from_array(&env, &[1u8; 32]);
         let sig = Bytes::from_array(&env, &[0u8; 64]);
 
         let cred_id = client.issue_credential(
@@ -355,6 +376,7 @@ mod tests {
             &subject,
             &CredentialType::Kyc,
             &claims,
+            &claims_hash,
             &sig,
             &0u64,
         );
@@ -372,9 +394,10 @@ mod tests {
         client.add_issuer(&issuer);
 
         let claims: Map<String, String> = Map::new(&env);
+        let claims_hash = BytesN::from_array(&env, &[0u8; 32]);
         let sig = Bytes::from_array(&env, &[0u8; 64]);
         let cred_id = client.issue_credential(
-            &issuer, &subject, &CredentialType::Kyc, &claims, &sig, &0u64,
+            &issuer, &subject, &CredentialType::Kyc, &claims, &claims_hash, &sig, &0u64,
         );
 
         client.revoke_credential(&issuer, &cred_id);
@@ -392,12 +415,13 @@ mod tests {
         client.add_issuer(&issuer);
 
         let claims: Map<String, String> = Map::new(&env);
+        let claims_hash = BytesN::from_array(&env, &[0u8; 32]);
         let sig = Bytes::from_array(&env, &[0u8; 64]);
         // expires_at is in the past (timestamp 1 is before the default ledger time)
         let past_expiry = env.ledger().timestamp().saturating_sub(1);
 
         client.issue_credential(
-            &issuer, &subject, &CredentialType::Kyc, &claims, &sig, &past_expiry,
+            &issuer, &subject, &CredentialType::Kyc, &claims, &claims_hash, &sig, &past_expiry,
         );
     }
 
@@ -411,10 +435,11 @@ mod tests {
         let subject = Address::generate(&env);
 
         let claims: Map<String, String> = Map::new(&env);
+        let claims_hash = BytesN::from_array(&env, &[0u8; 32]);
         let sig = Bytes::from_array(&env, &[0u8; 64]);
 
         client.issue_credential(
-            &unauthorized, &subject, &CredentialType::Kyc, &claims, &sig, &0u64,
+            &unauthorized, &subject, &CredentialType::Kyc, &claims, &claims_hash, &sig, &0u64,
         );
     }
 
@@ -428,11 +453,12 @@ mod tests {
         client.add_issuer(&issuer);
 
         let claims: Map<String, String> = Map::new(&env);
+        let claims_hash = BytesN::from_array(&env, &[0u8; 32]);
         let sig = Bytes::from_array(&env, &[0u8; 64]);
         let expires_at = env.ledger().timestamp() + 100;
 
         let cred_id = client.issue_credential(
-            &issuer, &subject, &CredentialType::Kyc, &claims, &sig, &expires_at,
+            &issuer, &subject, &CredentialType::Kyc, &claims, &claims_hash, &sig, &expires_at,
         );
 
         // Valid before expiry
@@ -460,9 +486,10 @@ mod tests {
         client.add_issuer(&issuer2);
 
         let claims: Map<String, String> = Map::new(&env);
+        let claims_hash = BytesN::from_array(&env, &[0u8; 32]);
         let sig = Bytes::from_array(&env, &[0u8; 64]);
         let cred_id = client.issue_credential(
-            &issuer1, &subject, &CredentialType::Kyc, &claims, &sig, &0u64,
+            &issuer1, &subject, &CredentialType::Kyc, &claims, &claims_hash, &sig, &0u64,
         );
 
         // issuer2 attempts to revoke a credential they did not issue
@@ -492,11 +519,12 @@ mod tests {
             String::from_str(&env, "name"),
             String::from_str(&env, "Alice"),
         );
+        let claims_hash = BytesN::from_array(&env, &[42u8; 32]);
         let sig = Bytes::from_array(&env, &[1u8; 64]);
         let expires_at = 9999u64;
 
         let cred_id = client.issue_credential(
-            &issuer, &subject, &CredentialType::Achievement, &claims, &sig, &expires_at,
+            &issuer, &subject, &CredentialType::Achievement, &claims, &claims_hash, &sig, &expires_at,
         );
 
         let cred = client.get_credential(&cred_id);
@@ -504,6 +532,7 @@ mod tests {
         assert_eq!(cred.subject, subject);
         assert_eq!(cred.credential_type, CredentialType::Achievement);
         assert_eq!(cred.expires_at, expires_at);
+        assert_eq!(cred.claims_hash, claims_hash);
         assert!(!cred.revoked);
     }
 
@@ -584,4 +613,26 @@ mod tests {
         assert_eq!(issuers_after.len(), 1);
         assert!(!issuers_after.contains(&issuer1));
         assert!(issuers_after.contains(&issuer2));
+    }
+
+    /// verify_claims_hash returns true for the correct hash and false for a wrong one.
+    #[test]
+    fn test_verify_claims_hash() {
+        let (env, _admin, client) = setup();
+
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.add_issuer(&issuer);
+
+        let claims: Map<String, String> = Map::new(&env);
+        let correct_hash = BytesN::from_array(&env, &[7u8; 32]);
+        let wrong_hash   = BytesN::from_array(&env, &[8u8; 32]);
+        let sig = Bytes::from_array(&env, &[0u8; 64]);
+
+        let cred_id = client.issue_credential(
+            &issuer, &subject, &CredentialType::Kyc, &claims, &correct_hash, &sig, &0u64,
+        );
+
+        assert!(client.verify_claims_hash(&cred_id, &correct_hash));
+        assert!(!client.verify_claims_hash(&cred_id, &wrong_hash));
     }

--- a/contracts/identity-registry/src/lib.rs
+++ b/contracts/identity-registry/src/lib.rs
@@ -122,7 +122,7 @@ impl IdentityRegistry {
         let count: u32 = env.storage().instance().get(&DID_COUNT).unwrap_or(0);
         env.storage().instance().set(&DID_COUNT, &(count + 1));
         
-        env.events().publish((IDENTITY, symbol_short!("created")), controller);
+        env.events().publish((IDENTITY, symbol_short!("created")), (controller, now));
 
         Ok(did_id)
     }
@@ -142,7 +142,13 @@ impl IdentityRegistry {
 
         storage.set(&key, &doc);
         storage.extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
-        env.events().publish((IDENTITY, symbol_short!("updated")), controller);
+
+        // Hash the DID id + updated_at as a deterministic metadata fingerprint
+        let mut hash_input = Bytes::new(&env);
+        hash_input.extend_from_slice(&doc.id.clone().into_bytes());
+        hash_input.extend_from_array(&doc.updated_at.to_be_bytes());
+        let meta_hash = env.crypto().sha256(&hash_input);
+        env.events().publish((IDENTITY, symbol_short!("updated")), (controller, meta_hash));
         Ok(())
     }
 
@@ -166,7 +172,7 @@ impl IdentityRegistry {
             env.storage().instance().set(&DID_COUNT, &(count - 1));
         }
         
-        env.events().publish((IDENTITY, symbol_short!("deactivated")), controller);
+        env.events().publish((IDENTITY, symbol_short!("deactivated")), (controller, doc.updated_at));
     }
 
     /// Resolve a DID document by controller address.

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -23,8 +23,13 @@ const DEF_THRESH: Symbol = symbol_short!("DEFTHRESH");
 #[derive(Clone, Debug, PartialEq, Copy)]
 pub enum ContractError {
     AlreadyInitialized = 1,
-    ReporterNotFound = 2,
+    ReporterNotFound   = 2,
+    RateLimitExceeded  = 3,
+    ReasonTooLong      = 4,
 }
+
+/// Minimum ledger interval between submissions from the same reporter for the same subject.
+const MIN_INTERVAL: u32 = 100;
 
 // ── Data types ────────────────────────────────────────────────────────────────
 
@@ -166,9 +171,17 @@ impl Reputation {
             return Err(ContractError::ReasonTooLong);
         }
 
-        let now = env.ledger().timestamp();
+        // Rate limiting: enforce MIN_INTERVAL ledgers between submissions per (reporter, subject)
+        let rate_key = Self::rate_key(&subject, &reporter);
+        let current_ledger = env.ledger().sequence();
+        if let Some(last_ledger) = env.storage().persistent().get::<(Symbol, Address, Address), u32>(&rate_key) {
+            if current_ledger <= last_ledger + MIN_INTERVAL {
+                return Err(ContractError::RateLimitExceeded);
+            }
+        }
+        env.storage().persistent().set(&rate_key, &current_ledger);
 
-        // Update aggregate record
+        let now = env.ledger().timestamp();
         let rec_key = Self::record_key(&subject);
         let mut record: ReputationRecord = env
             .storage()
@@ -324,6 +337,10 @@ impl Reputation {
     fn history_key(subject: &Address, reporter: &Address) -> (Symbol, Address, Address) {
         (symbol_short!("h"), subject.clone(), reporter.clone())
     }
+
+    fn rate_key(subject: &Address, reporter: &Address) -> (Symbol, Address, Address) {
+        (symbol_short!("rl"), subject.clone(), reporter.clone())
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -365,6 +382,7 @@ mod tests {
 
         let reason = String::from_str(&env, "completed KYC");
         client.submit_score(&reporter, &subject, &50, &reason);
+        env.ledger().with_mut(|li| li.sequence_number += 101);
         client.submit_score(&reporter, &subject, &25, &reason);
 
         let rec = client.get_reputation(&subject);
@@ -387,10 +405,11 @@ mod tests {
         client.initialize(&admin);
         client.add_reporter(&reporter);
 
-        // Submit 5 entries
+        // Submit 5 entries (advance ledger between each to bypass rate limit)
         for i in 0..5_i64 {
             let reason = String::from_str(&env, "reason");
             client.submit_score(&reporter, &subject, &i, &reason);
+            env.ledger().with_mut(|li| li.sequence_number += 101);
         }
 
         // First page: offset=0, limit=2 → entries 0,1
@@ -547,6 +566,7 @@ mod tests {
         let r1 = String::from_str(&env, "reporter1 reason");
         let r2 = String::from_str(&env, "reporter2 reason");
         client.submit_score(&reporter1, &subject, &10, &r1);
+        env.ledger().with_mut(|li| li.sequence_number += 101);
         client.submit_score(&reporter1, &subject, &20, &r1);
         client.submit_score(&reporter2, &subject, &99, &r2);
 
@@ -622,6 +642,37 @@ mod tests {
         // Unknown reporter should return error
         let result = client.try_get_history(&subject, &unknown, &0, &10);
         assert_eq!(result, Err(Ok(ContractError::ReporterNotFound)));
+    }
+
+    /// submit_score must return RateLimitExceeded when called again within MIN_INTERVAL ledgers.
+    #[test]
+    fn test_submit_score_rate_limit() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, Reputation);
+        let client = ReputationClient::new(&env, &contract_id);
+
+        let admin    = Address::generate(&env);
+        let reporter = Address::generate(&env);
+        let subject  = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.add_reporter(&reporter);
+
+        let reason = String::from_str(&env, "first");
+        // First submission succeeds
+        client.submit_score(&reporter, &subject, &10, &reason);
+
+        // Second submission in the same ledger must fail
+        let result = client.try_submit_score(&reporter, &subject, &10, &reason);
+        assert_eq!(result, Err(Ok(ContractError::RateLimitExceeded)));
+
+        // Advance ledger past MIN_INTERVAL (100)
+        env.ledger().with_mut(|li| li.sequence_number += 101);
+
+        // Now it should succeed again
+        client.submit_score(&reporter, &subject, &10, &reason);
     }
 
     /// Removing a reporter should decrement reporter_count in passes_sybil_check.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,9 +42,10 @@ Issues and verifies verifiable credentials. A maximum of **100 issuers** (`MAX_I
 | `transfer_admin(current_admin, new_admin)` | Transfer admin rights (current admin only) |
 | `add_issuer(issuer)` | Register a trusted issuer (admin) |
 | `remove_issuer(issuer)` | Remove an issuer (admin) |
-| `issue_credential(...)` | Issue a credential |
+| `issue_credential(issuer, subject, type, claims, claims_hash, sig, expires)` | Issue a credential |
 | `revoke_credential(issuer, id)` | Revoke a credential |
 | `verify_credential(id)` | Check validity |
+| `verify_claims_hash(id, hash)` | Verify off-chain claims hash matches stored hash |
 | `get_credential(id)` | Fetch full credential |
 
 ## DID Format
@@ -71,8 +72,25 @@ Issuer                Subject               Verifier
 ## Privacy
 
 - Claims are stored on-chain as key-value pairs (public by default)
-- For sensitive data, store an IPFS CID or encrypted reference in claims
+- For sensitive data, pass a SHA-256 hash of the off-chain claims payload as `claims_hash` to `issue_credential`; the raw claims can be stored off-chain (e.g. IPFS or encrypted storage) and verified on-chain with `verify_claims_hash(id, hash)`
 - ZKP integration is planned for selective disclosure without revealing raw claims
+
+## Contract Events
+
+### identity-registry
+
+| Event topic | Payload | Emitted by |
+|---|---|---|
+| `(IDENTITY, "created")` | `(controller: Address, timestamp: u64)` | `create_did` |
+| `(IDENTITY, "updated")` | `(controller: Address, metadata_hash: BytesN<32>)` | `update_did` |
+| `(IDENTITY, "deactivated")` | `(controller: Address, timestamp: u64)` | `deactivate_did` |
+
+### credential-manager
+
+| Event topic | Payload | Emitted by |
+|---|---|---|
+| `(CRED, "issued")` | `(id: BytesN<32>, subject: Address, issuer: Address, type: CredentialType)` | `issue_credential` |
+| `(CRED, "revoked")` | `(id: BytesN<32>, issuer: Address)` | `revoke_credential` |
 
 ## Storage
 

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -23,6 +23,7 @@ export class CredentialClient {
 
   /**
    * Issue a credential to a subject. Caller must be a registered issuer.
+   * @param claimsHashHex 64-char hex string (32 bytes) — SHA-256 hash of the off-chain claims payload.
    * @param signatureHex Optional pre-computed 64-byte signature as a 128-char hex string.
    *                     If omitted, the signature is derived from issuerKeypair.
    */
@@ -31,10 +32,17 @@ export class CredentialClient {
     subjectAddress: string,
     credentialType: CredentialType,
     claims: Record<string, string>,
+    claimsHashHex: string,
     expiresAt = 0,
     options?: CallOptions,
     signatureHex?: string
   ): Promise<{ credentialId: string } & WriteResult> {
+    if (!/^[0-9a-fA-F]{64}$/.test(claimsHashHex)) {
+      throw new Error(
+        "InvalidClaimsHashFormat: claimsHash must be a 64-character hex string (32 bytes)"
+      );
+    }
+
     if (signatureHex !== undefined) {
       if (!/^[0-9a-fA-F]{128}$/.test(signatureHex)) {
         throw new Error(
@@ -64,6 +72,7 @@ export class CredentialClient {
           nativeToScVal(subjectAddress, { type: "address" }),
           nativeToScVal(credentialType, { type: "symbol" }),
           nativeToScVal(claims, { type: "map" }),
+          nativeToScVal(Buffer.from(claimsHashHex, "hex"), { type: "bytes" }),
           nativeToScVal(signature, { type: "bytes" }),
           nativeToScVal(expiresAt, { type: "u64" })
         )

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -15,6 +15,8 @@ export interface Credential {
   issuer: string;
   credentialType: CredentialType;
   claims: Record<string, string>;
+  /** SHA-256 hash of the off-chain claims payload (hex-encoded 32 bytes) */
+  claimsHash: string;
   signature: string; // hex
   issuedAt: number;
   expiresAt: number; // 0 = no expiry


### PR DESCRIPTION
## Summary

This PR resolves four open issues in a single change set across the `credential-manager`, `identity-registry`, and `reputation` contracts, plus the TypeScript SDK and documentation.

---

## Issue #55 — Off-chain claims storage with on-chain hash ([#55](https://github.com/El-Chapo-Npm/Soroban-Identity/issues/55))

**Problem:** `credential-manager` stored claims as plaintext on-chain, exposing sensitive data.

**Changes:**
- Added `claims_hash: BytesN<32>` field to the `Credential` struct
- Added `verify_claims_hash(id, hash) -> bool` function — returns `true` when the supplied hash matches the stored hash
- Updated `issue_credential` signature to accept `claims_hash: BytesN<32>` as a new parameter
- Updated all existing tests to pass the new argument
- Added `test_verify_claims_hash` unit test
- SDK: added `claimsHash: string` field to the `Credential` interface in `types.ts`
- SDK: added `claimsHashHex` parameter to `CredentialClient.issueCredential` with hex-format validation

---

## Issue #56 — Rate limiting on reputation `submit_score` ([#56](https://github.com/El-Chapo-Npm/Soroban-Identity/issues/56))

**Problem:** `submit_score` had no rate limit, allowing a reporter to spam submissions and inflate/deflate scores.

**Changes:**
- Added `RateLimitExceeded = 3` and `ReasonTooLong = 4` variants to `ContractError`
- Added `MIN_INTERVAL: u32 = 100` ledger constant
- Added `rate_key(subject, reporter)` helper for persistent storage
- Enforced rate limit in `submit_score`: stores last submission ledger sequence per `(reporter, subject)` pair; returns `RateLimitExceeded` when `current_ledger <= last + MIN_INTERVAL`
- Fixed existing tests (`test_score_accumulation`, `test_get_history_pagination`, `test_get_history_per_reporter`) to advance the ledger by 101 between submissions
- Added `test_submit_score_rate_limit` unit test

---

## Issue #57 — Contract events for DID lifecycle in `identity-registry` ([#57](https://github.com/El-Chapo-Npm/Soroban-Identity/issues/57))

**Problem:** `identity-registry` emitted minimal events (controller address only), making it hard for indexers to track DID lifecycle changes.

**Changes:**
- `create_did` now emits `(IDENTITY, "created") → (controller: Address, timestamp: u64)`
- `update_did` now emits `(IDENTITY, "updated") → (controller: Address, meta_hash: BytesN<32>)` where `meta_hash = sha256(did_id_bytes ++ updated_at_bytes)`
- `deactivate_did` now emits `(IDENTITY, "deactivated") → (controller: Address, timestamp: u64)`
- Documented event schema in `docs/architecture.md` under a new **Contract Events** section

---

## Issue #58 — Events on credential issuance and revocation ([#58](https://github.com/El-Chapo-Npm/Soroban-Identity/issues/58))

**Problem:** `credential-manager` emitted minimal events, making it impossible for off-chain indexers to track credential lifecycle.

**Changes:**
- `issue_credential` now emits `(CRED, "issued") → (id: BytesN<32>, subject: Address, issuer: Address, credential_type: CredentialType)`
- `revoke_credential` now emits `(CRED, "revoked") → (id: BytesN<32>, issuer: Address)`
- Documented event schema in `docs/architecture.md`

---

## Testing

- SDK: 46/48 tests pass (`credentials`, `reputation`, `events`, `utils` suites all green)
- 2 pre-existing failures in `identity.test.ts` are unrelated to this PR (mock return value mismatch in `createDid` tests)
- Rust contract tests updated and new tests added for all four issues

## Files Changed

| File | Issues |
|---|---|
| `contracts/credential-manager/src/lib.rs` | #55, #58 |
| `contracts/identity-registry/src/lib.rs` | #57 |
| `contracts/reputation/src/lib.rs` | #56 |
| `sdk/src/types.ts` | #55 |
| `sdk/src/credentials.ts` | #55 |
| `docs/architecture.md` | #55, #57, #58 |

Closes #55
Closes #56
Closes #57
Closes #58