### PR TITLE
fix(seo): update page title, add meta/OG tags and favicon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Soroban Identity</title>
+
+    <title>Soroban Identity — Decentralized Identity on Stellar</title>
+    <meta name="description" content="Create, manage, and verify decentralized identities and verifiable credentials on the Stellar network using Soroban smart contracts." />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Soroban Identity — Decentralized Identity on Stellar" />
+    <meta property="og:description" content="Create, manage, and verify decentralized identities and verifiable credentials on the Stellar network using Soroban smart contracts." />
+    <meta property="og:type" content="website" />
+
+    <!-- Favicon (Stellar logo mark as inline SVG data URI) -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='16' fill='%23000'/%3E%3Cpath d='M24.5 9.5 8 17.2l-.5-1.1L24 8.4zM8 14.8l16.5-7.7.5 1.1L8.5 15.9zm0 4.4 16.5-7.7.5 1.1L8.5 20.3zm0 4.4 16.5-7.7.5 1.1L8.5 24.7z' fill='%23fff'/%3E%3C/svg%3E" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
 Fixes #133 

- Title: 'Soroban Identity — Decentralized Identity on Stellar'
- meta description added
- og:title and og:description added
- Inline SVG favicon (Stellar logo mark, no external asset needed)fix(seo): update page title, add meta/OG tags and favicon
  
  The browser tab showed the default 'Vite + React + TS' title and the
  page had no meta description, Open Graph tags, or favicon.
  
  Changes to frontend/index.html:
  - Title: 'Soroban Identity — Decentralized Identity on Stellar'
  - Add meta description
  - Add og:title, og:description, og:type for social sharing
  - Add inline SVG favicon (Stellar logo mark, no external asset required)
  
 