### PR TITLE
feat: Add SDK connection health check utility (#145)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { SorobanRpc } from "@stellar/stellar-sdk";
 import IdentityPanel from "./components/IdentityPanel";
 import CredentialsPanel from "./components/CredentialsPanel";
 import WalletButton from "./components/WalletButton";
 import { useWallet } from "./hooks/useWallet";
 import { useCredentialExpiryCheck } from "./hooks/useCredentialExpiryCheck";
+import { checkConnection, TESTNET_CONFIG } from "../../sdk/src/index";
 import type { Credential } from "../../sdk/src/types";
 
 type Tab = "identity" | "credentials";
@@ -32,6 +34,7 @@ export default function App() {
   const wallet = useWallet();
   const [isDark, toggleDark] = useDarkMode();
   const { t, i18n } = useTranslation();
+  const [isConnected, setIsConnected] = useState<boolean | null>(null);
 
   // Check for verify query param on load
   useEffect(() => {
@@ -41,6 +44,16 @@ export default function App() {
       setVerifyId(verifyParam);
       setTab("credentials");
     }
+  }, []);
+
+  // Check RPC connection health on load
+  useEffect(() => {
+    const checkRpcHealth = async () => {
+      const server = new SorobanRpc.Server(TESTNET_CONFIG.rpcUrl);
+      const healthy = await checkConnection(server);
+      setIsConnected(healthy);
+    };
+    checkRpcHealth();
   }, []);
 
   // Mock fetch — replace with CredentialClient.getCredentialsBySubject() when wired
@@ -66,6 +79,23 @@ export default function App() {
         <h1>{t("app.title")}</h1>
         <p>{t("app.subtitle")}</p>
         <div style={{ position: "absolute", top: "1rem", right: 0, display: "flex", gap: "0.5rem", alignItems: "center" }}>
+          {isConnected !== null && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+                padding: "0.4rem 0.8rem",
+                borderRadius: "0.25rem",
+                backgroundColor: isConnected ? "var(--success-bg, #d4edda)" : "var(--danger-bg, #f8d7da)",
+                color: isConnected ? "var(--success-text, #155724)" : "var(--danger-text, #721c24)",
+                fontSize: "0.85rem",
+              }}
+            >
+              <span style={{ display: "inline-block", width: "8px", height: "8px", borderRadius: "50%", backgroundColor: isConnected ? "#28a745" : "#dc3545" }} />
+              {isConnected ? t("app.networkOnline") : t("app.networkOffline")}
+            </div>
+          )}
           <button className="theme-toggle" onClick={toggleLang} aria-label="Switch language">
             {i18n.language === "en" ? "ES" : "EN"}
           </button>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3,7 +3,9 @@
     "title": "Soroban Identity",
     "subtitle": "Decentralized Identity for a Trustless World",
     "lightMode": "☀ Light",
-    "darkMode": "☾ Dark"
+    "darkMode": "☾ Dark",
+    "networkOnline": "Network OK",
+    "networkOffline": "Network Error"
   },
   "tabs": {
     "identity": "Identity (DID)",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -3,7 +3,9 @@
     "title": "Soroban Identity",
     "subtitle": "Identidad Descentralizada para un Mundo sin Confianza",
     "lightMode": "☀ Claro",
-    "darkMode": "☾ Oscuro"
+    "darkMode": "☾ Oscuro",
+    "networkOnline": "Red Conectada",
+    "networkOffline": "Error de Red"
   },
   "tabs": {
     "identity": "Identidad (DID)",

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -2,7 +2,7 @@ export { IdentityClient } from "./identity";
 export { CredentialClient } from "./credentials";
 export { ReputationClient } from "./reputation";
 export { SorobanEventListener } from "./events";
-export { retryWithBackoff, validateStellarAddress } from "./utils";
+export { retryWithBackoff, checkConnection, validateStellarAddress } from "./utils";
 export type {
   DidDocument,
   Credential,

--- a/sdk/src/utils.test.ts
+++ b/sdk/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { validateStellarAddress } from "./utils";
+import { validateStellarAddress, checkConnection } from "./utils";
 
 vi.mock("@stellar/stellar-sdk", () => ({
   StrKey: {
@@ -29,5 +29,30 @@ describe("validateStellarAddress", () => {
 
   it("error message includes the invalid address", () => {
     expect(() => validateStellarAddress("bad")).toThrow('"bad"');
+  });
+});
+
+describe("checkConnection", () => {
+  it("returns true when getLatestLedger succeeds", async () => {
+    const mockServer = {
+      getLatestLedger: vi.fn().mockResolvedValue({ ledger_sequence: 123 }),
+    };
+    const result = await checkConnection(mockServer as any);
+    expect(result).toBe(true);
+  });
+
+  it("returns false when getLatestLedger throws an error", async () => {
+    const mockServer = {
+      getLatestLedger: vi.fn().mockRejectedValue(new Error("Network error")),
+    };
+    const result = await checkConnection(mockServer as any);
+    expect(result).toBe(false);
+  });
+
+  it("does not throw on network error", async () => {
+    const mockServer = {
+      getLatestLedger: vi.fn().mockRejectedValue(new Error("Connection timeout")),
+    };
+    await expect(checkConnection(mockServer as any)).resolves.toBe(false);
   });
 });

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -81,3 +81,19 @@ export function validateStellarAddress(address: string): void {
     throw new Error(`InvalidAddress: "${address}" is not a valid Stellar address`);
   }
 }
+
+/**
+ * Checks if the RPC connection is healthy.
+ * Returns false on any network or server error without throwing.
+ *
+ * @param server - SorobanRpc.Server instance
+ * @returns Promise<boolean> - true if connection is healthy, false otherwise
+ */
+export async function checkConnection(server: SorobanRpc.Server): Promise<boolean> {
+  try {
+    await server.getLatestLedger();
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
- Add checkConnection() utility in sdk/src/utils.ts that uses server.getLatestLedger()
- Returns Promise<boolean> - true if healthy, false on network/server errors
- Export from sdk/src/index.ts
- Add unit tests for success and error cases
- Integrate into frontend App.tsx with network status badge
- Add translations for network status (en/es locales)
- Closes #145