### PR TITLE
feat(frontend): credential status badges and network switcher

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Which Stellar network the frontend talks to. One of: testnet | mainnet.
+# Defaults to testnet when unset or set to anything other than "mainnet".
+VITE_NETWORK=testnet

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,8 @@ import CredentialsPanel from "./components/CredentialsPanel";
 import WalletButton from "./components/WalletButton";
 import { useWallet } from "./hooks/useWallet";
 import { useCredentialExpiryCheck } from "./hooks/useCredentialExpiryCheck";
-import { checkConnection, TESTNET_CONFIG } from "../../sdk/src/index";
+import { checkConnection } from "../../sdk/src/index";
+import { getActiveNetwork, getNetworkConfig, isMainnet } from "./network";
 import type { Credential } from "../../sdk/src/types";
 
 type Tab = "identity" | "credentials";
@@ -46,15 +47,19 @@ export default function App() {
     }
   }, []);
 
+  const network = getActiveNetwork();
+  const networkConfig = getNetworkConfig(network);
+  const onMainnet = isMainnet(network);
+
   // Check RPC connection health on load
   useEffect(() => {
     const checkRpcHealth = async () => {
-      const server = new SorobanRpc.Server(TESTNET_CONFIG.rpcUrl);
+      const server = new SorobanRpc.Server(networkConfig.rpcUrl);
       const healthy = await checkConnection(server);
       setIsConnected(healthy);
     };
     checkRpcHealth();
-  }, []);
+  }, [networkConfig.rpcUrl]);
 
   // Mock fetch — replace with CredentialClient.getCredentialsBySubject() when wired
   const fetchCredentials = useCallback(async (_address: string): Promise<Credential[]> => {
@@ -79,6 +84,22 @@ export default function App() {
         <h1>{t("app.title")}</h1>
         <p>{t("app.subtitle")}</p>
         <div style={{ position: "absolute", top: "1rem", right: 0, display: "flex", gap: "0.5rem", alignItems: "center" }}>
+          <span
+            aria-label={`Active network: ${network}`}
+            title={`Network: ${network} (${networkConfig.rpcUrl})`}
+            style={{
+              padding: "0.3rem 0.6rem",
+              borderRadius: "999px",
+              fontSize: "0.75rem",
+              fontWeight: 600,
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+              background: onMainnet ? "var(--badge-red-bg)" : "var(--badge-green-bg)",
+              color: onMainnet ? "var(--badge-red-text)" : "var(--badge-green-text)",
+            }}
+          >
+            {network}
+          </span>
           {isConnected !== null && (
             <div
               style={{
@@ -109,6 +130,26 @@ export default function App() {
           <WalletButton wallet={wallet} />
         </div>
       </header>
+
+      {onMainnet && (
+        <div
+          role="alert"
+          aria-label="Mainnet warning"
+          style={{
+            background: "var(--badge-red-bg)",
+            color: "var(--badge-red-text)",
+            border: "1px solid var(--badge-red-text)",
+            borderRadius: "0.5rem",
+            padding: "0.6rem 1rem",
+            marginBottom: "1rem",
+            fontSize: "0.9rem",
+            fontWeight: 600,
+          }}
+        >
+          ⚠ You are connected to Stellar <strong>mainnet</strong>. All actions submit real
+          transactions and may incur on-chain fees.
+        </div>
+      )}
 
       {notification && !notification.dismissed && (
         <div

--- a/frontend/src/components/CredentialsPanel.tsx
+++ b/frontend/src/components/CredentialsPanel.tsx
@@ -67,6 +67,7 @@ const MOCK_CREDENTIALS = [
   { id: "abc003", credentialType: "Reputation" as CredentialType, subject: "GABC…", issuer: "GISSUER", claims: { score: "850", level: "gold" }, claimsHash: "hash3", signature: "sig3", issuedAt: Date.now() / 1000 - 1000, expiresAt: Math.floor((Date.now() + 3 * 24 * 60 * 60 * 1000) / 1000), revoked: false },
   { id: "abc004", credentialType: "Achievement" as CredentialType, subject: "GABC…", issuer: "GISSUER", claims: {}, claimsHash: "hash4", signature: "sig4", issuedAt: Date.now() / 1000 - 1000, expiresAt: Math.floor((Date.now() - 5 * 24 * 60 * 60 * 1000) / 1000), revoked: false },
   { id: "abc005", credentialType: "Custom" as CredentialType, subject: "GABC…", issuer: "GISSUER", claims: { custom_field: "custom_value" }, claimsHash: "hash5", signature: "sig5", issuedAt: Date.now() / 1000 - 1000, expiresAt: Math.floor((Date.now() + 30 * 24 * 60 * 60 * 1000) / 1000), revoked: false },
+  { id: "abc006", credentialType: "Kyc" as CredentialType, subject: "GABC…", issuer: "GISSUER", claims: { reason: "compromised" }, claimsHash: "hash6", signature: "sig6", issuedAt: Date.now() / 1000 - 2000, expiresAt: Math.floor((Date.now() + 30 * 24 * 60 * 60 * 1000) / 1000), revoked: true },
 ];
 
 const FILTER_OPTIONS: FilterType[] = ["All", "Kyc", "Reputation", "Achievement", "Custom"];
@@ -82,6 +83,37 @@ function countByType(creds: typeof MOCK_CREDENTIALS, type: FilterType): number {
   if (type === "All") return creds.length;
   return creds.filter((c) => c.credentialType === type).length;
 }
+
+type CredentialStatus = "active" | "expired" | "revoked";
+
+function credentialStatus(cred: { revoked: boolean; expiresAt: number }): CredentialStatus {
+  if (cred.revoked) return "revoked";
+  if (cred.expiresAt !== 0 && cred.expiresAt * 1000 < Date.now()) return "expired";
+  return "active";
+}
+
+const STATUS_BADGE_CLASS: Record<CredentialStatus, string> = {
+  active: "badge badge-green",
+  expired: "badge badge-gray",
+  revoked: "badge badge-red",
+};
+
+const STATUS_LABEL: Record<CredentialStatus, string> = {
+  active: "Active",
+  expired: "Expired",
+  revoked: "Revoked",
+};
+
+/**
+ * Sort order: active credentials first, then expired, then revoked. Within
+ * each bucket the original input order is preserved. Verifiers should see
+ * still-presentable credentials before stale ones.
+ */
+const STATUS_RANK: Record<CredentialStatus, number> = {
+  active: 0,
+  expired: 1,
+  revoked: 2,
+};
 
 export default function CredentialsPanel({ wallet, verifyId }: Props) {
   const [credId, setCredId] = useState("");
@@ -233,10 +265,18 @@ export default function CredentialsPanel({ wallet, verifyId }: Props) {
 
   const displayCredentials = fetchedCredentials ?? MOCK_CREDENTIALS;
 
-  const filteredCredentials =
+  const filteredCredentials = (
     activeFilter === "All"
       ? displayCredentials
-      : displayCredentials.filter((c) => c.credentialType === activeFilter);
+      : displayCredentials.filter((c) => c.credentialType === activeFilter)
+  )
+    .map((c, originalIndex) => ({ c, originalIndex, status: credentialStatus(c) }))
+    .sort((a, b) => {
+      const rank = STATUS_RANK[a.status] - STATUS_RANK[b.status];
+      if (rank !== 0) return rank;
+      return a.originalIndex - b.originalIndex;
+    })
+    .map(({ c }) => c);
 
   const handleIssue = async () => {
     if (!wallet.connected) return;
@@ -373,6 +413,17 @@ export default function CredentialsPanel({ wallet, verifyId }: Props) {
                   </span>
                   <span style={{ fontFamily: "monospace", color: "var(--text-muted)" }}>{cred.id}</span>
                   <span className="badge badge-green">{cred.credentialType}</span>
+                  {(() => {
+                    const status = credentialStatus(cred);
+                    return (
+                      <span
+                        className={STATUS_BADGE_CLASS[status]}
+                        aria-label={`Credential status: ${STATUS_LABEL[status]}`}
+                      >
+                        {STATUS_LABEL[status]}
+                      </span>
+                    );
+                  })()}
                   <span style={getExpiryStyle(cred.expiresAt)}>{formatExpiry(cred.expiresAt)}</span>
                   <button
                     onClick={(e) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -234,6 +234,7 @@ button:disabled { background: var(--btn-disabled-bg); color: var(--btn-disabled-
 .badge-green  { background: var(--badge-green-bg);  color: var(--badge-green-text); }
 .badge-red    { background: var(--badge-red-bg);    color: var(--badge-red-text); }
 .badge-purple { background: var(--badge-purple-bg); color: var(--badge-purple-text); }
+.badge-gray   { background: var(--border-input);    color: var(--text-muted); }
 
 .result {
   margin-top: 1rem;

--- a/frontend/src/network.ts
+++ b/frontend/src/network.ts
@@ -1,0 +1,26 @@
+import {
+  MAINNET_CONFIG,
+  TESTNET_CONFIG,
+  type SorobanIdentityConfig,
+} from "../../sdk/src/index";
+
+export type NetworkName = "testnet" | "mainnet";
+
+/**
+ * Resolve the active network from the `VITE_NETWORK` env var.
+ *
+ * Anything other than the literal string "mainnet" falls back to testnet —
+ * the safe default for development.
+ */
+export function getActiveNetwork(): NetworkName {
+  const raw = (import.meta.env.VITE_NETWORK ?? "").toString().toLowerCase();
+  return raw === "mainnet" ? "mainnet" : "testnet";
+}
+
+export function getNetworkConfig(network: NetworkName = getActiveNetwork()): SorobanIdentityConfig {
+  return network === "mainnet" ? MAINNET_CONFIG : TESTNET_CONFIG;
+}
+
+export function isMainnet(network: NetworkName = getActiveNetwork()): boolean {
+  return network === "mainnet";
+}


### PR DESCRIPTION
## Summary
Two related frontend improvements:

- **CredentialsPanel status badges (#102)** — derives an Active / Expired / Revoked status per credential and renders a green/grey/red badge next to the type badge. Revoked and expired credentials are sorted to the bottom so verifiers see presentable credentials first. Added a sample revoked mock so the new state is visible in the dev shell.
- **Network switcher (#104)** — new \`VITE_NETWORK\` env var (\`frontend/.env.example\` added). \`src/network.ts\` reads it, falls back to \`testnet\`, and exposes \`getNetworkConfig\` / \`isMainnet\`. \`App.tsx\` now uses the active network's RPC URL for health checks, shows a network pill in the header, and renders a prominent red banner when on mainnet.

## DoD coverage

#102:
- [x] Revoked badge for revoked credentials
- [x] Active and Expired badges added
- [x] Revoked/expired sorted to bottom
- [x] No new dependencies required

#104:
- [x] \`VITE_NETWORK\` supported
- [x] Network config map (\`getNetworkConfig\`) created
- [x] Network badge shown in header
- [x] Mainnet warning banner displayed

## Not in this PR

- #103 (Rust integration tests) was deferred: upstream contracts on \`main\` currently fail to compile against the resolved \`soroban-sdk\` version (21.7.7) — \`cargo build -p reputation\` errors on \`update_current_contract_wasm\` and \`Ledger::with_mut\` is no longer in scope in the existing unit tests. That blocks adding any new cross-contract test crate. Happy to follow up once the SDK pin / migration is sorted.

## Closes
closes #102
closes #104

## Test plan
- [x] \`tsc --noEmit\` clean on the changed frontend files
- [ ] Manual: open the app with \`VITE_NETWORK=testnet\` (default), confirm testnet pill + no banner; rerun with \`VITE_NETWORK=mainnet\`, confirm red mainnet pill + warning banner.
- [ ] Manual: open Credentials tab, confirm the revoked sample renders with the red Revoked badge and is sorted below active ones.
