### PR TITLE
feat: server caching, computeCredentialId, isInitialized, type-check CI

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -29,6 +29,10 @@ jobs:
         working-directory: sdk
         run: npm run build
 
+      - name: Type check
+        working-directory: sdk
+        run: npm run type-check
+
       - name: Test
         working-directory: sdk
         run: npm test

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,8 +6,9 @@ import CredentialsPanel from "./components/CredentialsPanel";
 import WalletButton from "./components/WalletButton";
 import { useWallet } from "./hooks/useWallet";
 import { useCredentialExpiryCheck } from "./hooks/useCredentialExpiryCheck";
-import { checkConnection, TESTNET_CONFIG } from "../../sdk/src/index";
+import { checkConnection, TESTNET_CONFIG, IdentityClient, CredentialClient, ReputationClient } from "../../sdk/src/index";
 import { getAppConfig } from "./config";
+import { getActiveNetwork, getNetworkConfig, isMainnet } from "./network";
 import type { Credential } from "../../sdk/src/types";
 
 type Tab = "identity" | "credentials";
@@ -36,6 +37,7 @@ export default function App() {
   const [isDark, toggleDark] = useDarkMode();
   const { t, i18n } = useTranslation();
   const [isConnected, setIsConnected] = useState<boolean | null>(null);
+  const [uninitializedContracts, setUninitializedContracts] = useState<string[]>([]);
 
   // Check for verify query param on load
   useEffect(() => {
@@ -60,6 +62,27 @@ export default function App() {
       setIsConnected(healthy);
     };
     checkRpcHealth();
+  }, [networkConfig.rpcUrl]);
+
+  // Check contract initialization on load
+  useEffect(() => {
+    const checkInit = async () => {
+      const config = getAppConfig();
+      const identity = new IdentityClient(config);
+      const credentials = new CredentialClient(config);
+      const reputation = new ReputationClient(config);
+      const [idOk, credOk, repOk] = await Promise.all([
+        identity.isInitialized(),
+        credentials.isInitialized(),
+        reputation.isInitialized(),
+      ]);
+      const uninitialized: string[] = [];
+      if (!idOk) uninitialized.push("Identity Registry");
+      if (!credOk) uninitialized.push("Credential Manager");
+      if (!repOk) uninitialized.push("Reputation");
+      setUninitializedContracts(uninitialized);
+    };
+    checkInit();
   }, [networkConfig.rpcUrl]);
 
   // Mock fetch — replace with CredentialClient.getCredentialsBySubject() when wired
@@ -157,6 +180,33 @@ export default function App() {
           <WalletButton wallet={wallet} />
         </div>
       </header>
+
+      {uninitializedContracts.length > 0 && (
+        <div
+          role="alert"
+          aria-label="Contract not initialized warning"
+          style={{
+            background: "var(--warning-bg, #fff3cd)",
+            color: "var(--warning-text, #856404)",
+            border: "1px solid var(--warning-border, #ffc107)",
+            borderRadius: "0.5rem",
+            padding: "0.6rem 1rem",
+            marginBottom: "1rem",
+            fontSize: "0.9rem",
+          }}
+        >
+          ⚠ Contract not initialized: <strong>{uninitializedContracts.join(", ")}</strong>.
+          Please run the deploy script and update your contract IDs.{" "}
+          <a
+            href="docs/architecture.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "inherit", textDecoration: "underline" }}
+          >
+            Deployment guide
+          </a>
+        </div>
+      )}
 
       {onMainnet && (
         <div

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "vitest run"
+    "test": "vitest run",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0"

--- a/sdk/src/base-client.ts
+++ b/sdk/src/base-client.ts
@@ -1,0 +1,14 @@
+import { SorobanRpc } from "@stellar/stellar-sdk";
+
+const serverCache = new Map<string, SorobanRpc.Server>();
+
+export function getOrCreateServer(rpcUrl: string): SorobanRpc.Server {
+  if (!serverCache.has(rpcUrl)) {
+    serverCache.set(rpcUrl, new SorobanRpc.Server(rpcUrl));
+  }
+  return serverCache.get(rpcUrl)!;
+}
+
+export function clearServerCache(): void {
+  serverCache.clear();
+}

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -9,6 +9,9 @@ import {
 } from "@stellar/stellar-sdk";
 import type { CallOptions, Credential, CredentialStorageStats, CredentialType, SorobanIdentityConfig, VerifyResult, WriteResult } from "./types";
 import { retryWithBackoff, validateStellarAddress, pollTransactionStatus } from "./utils";
+import { getOrCreateServer } from "./base-client";
+
+const PROBE_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
 
 export class CredentialClient {
   private server: SorobanRpc.Server;
@@ -17,8 +20,37 @@ export class CredentialClient {
 
   constructor(config: SorobanIdentityConfig) {
     this.config = config;
-    this.server = new SorobanRpc.Server(config.rpcUrl);
+    this.server = getOrCreateServer(config.rpcUrl);
     this.contract = new Contract(config.credentialManagerId);
+  }
+
+  /** Returns true if the credential-manager contract has been initialized. */
+  async isInitialized(): Promise<boolean> {
+    try {
+      const account = await this.server.getAccount(PROBE_ADDRESS);
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.config.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "is_issuer",
+            nativeToScVal(PROBE_ADDRESS, { type: "address" })
+          )
+        )
+        .setTimeout(10)
+        .build();
+      const result = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(result)) {
+        const err: string = (result as { error: string }).error ?? "";
+        if (err.includes("not initialized") || err.includes("NotInitialized") || err.includes("#0")) {
+          return false;
+        }
+      }
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/sdk/src/identity.ts
+++ b/sdk/src/identity.ts
@@ -9,6 +9,10 @@ import {
 } from "@stellar/stellar-sdk";
 import type { CallOptions, DidDocument, IdentityStorageStats, SorobanIdentityConfig, WriteResult } from "./types";
 import { retryWithBackoff, validateStellarAddress, pollTransactionStatus } from "./utils";
+import { getOrCreateServer } from "./base-client";
+
+// Dummy address used for lightweight initialization probes
+const PROBE_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
 
 export class IdentityClient {
   private server: SorobanRpc.Server;
@@ -17,8 +21,40 @@ export class IdentityClient {
 
   constructor(config: SorobanIdentityConfig) {
     this.config = config;
-    this.server = new SorobanRpc.Server(config.rpcUrl);
+    this.server = getOrCreateServer(config.rpcUrl);
     this.contract = new Contract(config.identityRegistryId);
+  }
+
+  /**
+   * Returns true if the identity-registry contract has been initialized.
+   * Uses a lightweight read call; returns false on any contract-level error.
+   */
+  async isInitialized(): Promise<boolean> {
+    try {
+      const account = await this.server.getAccount(PROBE_ADDRESS);
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.config.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            "has_active_did",
+            nativeToScVal(PROBE_ADDRESS, { type: "address" })
+          )
+        )
+        .setTimeout(10)
+        .build();
+      const result = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(result)) {
+        const err: string = (result as { error: string }).error ?? "";
+        if (err.includes("not initialized") || err.includes("NotInitialized") || err.includes("#0")) {
+          return false;
+        }
+      }
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -7,7 +7,9 @@ export {
   retryWithBackoff,
   checkConnection,
   validateStellarAddress,
+  computeCredentialId,
 } from './utils';
+export { clearServerCache } from './base-client';
 export type {
   DidDocument,
   Credential,

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -19,6 +19,9 @@ import {
   pollTransactionStatus,
 } from './utils';
 import { SorobanTransactionBuilder } from './transaction-builder';
+import { getOrCreateServer } from './base-client';
+
+const PROBE_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
 
 export interface ReputationRecord {
   subject: string;
@@ -41,8 +44,37 @@ export class ReputationClient {
 
   constructor(config: SorobanIdentityConfig) {
     this.config = config;
-    this.server = new SorobanRpc.Server(config.rpcUrl);
+    this.server = getOrCreateServer(config.rpcUrl);
     this.contract = new Contract(config.reputationId);
+  }
+
+  /** Returns true if the reputation contract has been initialized. */
+  async isInitialized(): Promise<boolean> {
+    try {
+      const account = await this.server.getAccount(PROBE_ADDRESS);
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.config.networkPassphrase,
+      })
+        .addOperation(
+          this.contract.call(
+            'passes_sybil_check_default',
+            nativeToScVal(PROBE_ADDRESS, { type: 'address' })
+          )
+        )
+        .setTimeout(10)
+        .build();
+      const result = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(result)) {
+        const err: string = (result as { error: string }).error ?? '';
+        if (err.includes('not initialized') || err.includes('NotInitialized') || err.includes('#0')) {
+          return false;
+        }
+      }
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /** Get the list of all registered reporters. */

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -1,4 +1,5 @@
-import { StrKey, SorobanRpc } from "@stellar/stellar-sdk";
+import { StrKey, SorobanRpc, hash } from "@stellar/stellar-sdk";
+import type { CredentialType } from "./types";
 
 /**
  * Retries an async function with exponential backoff on transient network errors.
@@ -96,4 +97,19 @@ export async function checkConnection(server: SorobanRpc.Server): Promise<boolea
   } catch {
     return false;
   }
+}
+
+/**
+ * Deterministically computes a credential ID from issuer, subject, and type.
+ * Mirrors the derivation used by the credential-manager contract.
+ *
+ * @returns 64-character hex string (32-byte SHA-256 hash)
+ */
+export function computeCredentialId(
+  issuer: string,
+  subject: string,
+  credentialType: CredentialType
+): string {
+  const input = [issuer, subject, credentialType].join(":");
+  return Buffer.from(hash(Buffer.from(input))).toString("hex");
 }


### PR DESCRIPTION
## Summary

Resolves all four open issues in one PR.

### #169 — SorobanRpc.Server instance caching
- Created `sdk/src/base-client.ts` with a module-level `Map<string, SorobanRpc.Server>` cache
- `getOrCreateServer(rpcUrl)` returns a cached instance, creating one only on first call
- All three clients (`IdentityClient`, `CredentialClient`, `ReputationClient`) now use `getOrCreateServer()` instead of `new SorobanRpc.Server()`
- `clearServerCache()` exported from `sdk/src/index.ts` for testing and cleanup

### #168 — `computeCredentialId` utility
- Added `computeCredentialId(issuer, subject, credentialType)` to `sdk/src/utils.ts`
- Uses `hash()` from `@stellar/stellar-sdk` to mirror the contract's deterministic derivation
- Exported from `sdk/src/index.ts`

### #166 — `isInitialized()` + frontend banner
- Added `isInitialized(): Promise<boolean>` to all three SDK clients
- Each method makes a lightweight read simulation; returns `false` on a not-initialized error code, `true` otherwise
- `frontend/src/App.tsx` checks all three contracts on load and shows a warning banner listing uninitialized contracts with a link to the deployment guide

### #167 — TypeScript strict mode + type-check CI
- `strict: true` was already present in `sdk/tsconfig.json` — no change needed
- Added `"type-check": "tsc --noEmit"` script to `sdk/package.json`
- Added a **Type check** step to `.github/workflows/sdk-ci.yml` (runs after build, before tests)

## Testing
- `npm run build` — passes (zero TS errors)
- `npm run type-check` — passes
- `npm test` — 66/66 tests pass across 5 test files

Closes #166
Closes #167
Closes #168
Closes #169