### PR TITLE
Fix 4 critical issues: rate limiting, RPC failover, contract errors, …

### DIFF
--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -25,6 +25,10 @@ pub enum ContractError {
     CredentialNotFound = 3,
     CredentialRevoked = 4,
     CredentialAlreadyExists = 5,
+    NotInitialized = 6,
+    Unauthorized = 7,
+    MaxIssuersReached = 8,
+    CredentialExpired = 9,
 }
 
 /// ~1 year in ledgers (5-second ledger close time). Used as the max TTL cap.
@@ -115,23 +119,24 @@ impl CredentialManager {
     /// * `current_admin` - The current admin address (must sign the transaction).
     /// * `new_admin` - The address to transfer admin rights to.
     ///
-    /// # Panics
-    /// Panics if `current_admin` does not match the stored admin address.
-    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) {
+    /// # Errors
+    /// Returns [`ContractError::Unauthorized`] if `current_admin` does not match the stored admin address.
+    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), ContractError> {
         current_admin.require_auth();
         let stored: Address = env
             .storage()
             .instance()
             .get(&ADMIN)
-            .expect("not initialized");
+            .ok_or(ContractError::NotInitialized)?;
         if stored != current_admin {
-            panic!("not the admin");
+            return Err(ContractError::Unauthorized);
         }
         env.storage().instance().set(&ADMIN, &new_admin);
         env.events().publish(
             (ADMIN, symbol_short!("transfer")),
             (current_admin, new_admin),
         );
+        Ok(())
     }
 
     /// Upgrades the contract WASM to a new hash. Only the admin can call this.
@@ -141,19 +146,20 @@ impl CredentialManager {
     /// * `admin` - The admin address (must sign the transaction).
     /// * `new_wasm_hash` - The hash of the new WASM binary to upgrade to.
     ///
-    /// # Panics
-    /// Panics if `admin` does not match the stored admin address.
-    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: Bytes) {
+    /// # Errors
+    /// Returns [`ContractError::Unauthorized`] if `admin` does not match the stored admin address.
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: Bytes) -> Result<(), ContractError> {
         admin.require_auth();
         let stored: Address = env
             .storage()
             .instance()
             .get(&ADMIN)
-            .expect("not initialized");
+            .ok_or(ContractError::NotInitialized)?;
         if stored != admin {
-            panic!("not the admin");
+            return Err(ContractError::Unauthorized);
         }
         env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 
     /// Registers a trusted issuer (admin only).
@@ -167,18 +173,19 @@ impl CredentialManager {
     ///
     /// # Panics
     /// Panics with `"MaxIssuersReached"` if the issuer cap has been reached.
-    pub fn add_issuer(env: Env, issuer: Address) {
+    pub fn add_issuer(env: Env, issuer: Address) -> Result<(), ContractError> {
         Self::require_admin(&env);
         let mut issuers = Self::get_issuers_internal(&env);
         if !issuers.contains(&issuer) {
             if issuers.len() >= MAX_ISSUERS {
-                panic!("MaxIssuersReached");
+                return Err(ContractError::MaxIssuersReached);
             }
             issuers.push_back(issuer.clone());
             env.storage().instance().set(&ISSUER, &issuers);
             env.events()
                 .publish((ISSUER, symbol_short!("added")), issuer);
         }
+        Ok(())
     }
 
     /// Removes a trusted issuer (admin only).
@@ -189,8 +196,8 @@ impl CredentialManager {
     /// # Arguments
     /// * `env` - The Soroban environment.
     /// * `issuer` - The issuer address to remove.
-    pub fn remove_issuer(env: Env, issuer: Address) {
-        Self::require_admin(&env);
+    pub fn remove_issuer(env: Env, issuer: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         let issuers = Self::get_issuers_internal(&env);
         let mut updated = Vec::new(&env);
         for i in issuers.iter() {
@@ -199,6 +206,7 @@ impl CredentialManager {
             }
         }
         env.storage().instance().set(&ISSUER, &updated);
+        Ok(())
     }
 
     // ── Credential lifecycle ──────────────────────────────────────────────────
@@ -243,12 +251,12 @@ impl CredentialManager {
         expires_at: u64,
     ) -> Result<BytesN<32>, ContractError> {
         issuer.require_auth();
-        Self::require_issuer(&env, &issuer);
+        Self::require_issuer(&env, &issuer)?;
 
         let now = env.ledger().timestamp();
 
         if expires_at != 0 && expires_at <= now {
-            panic!("CredentialAlreadyExpired");
+            return Err(ContractError::CredentialExpired);
         }
 
         // Deterministic ID: sha256(issuer_bytes || subject_bytes || type_tag)
@@ -479,20 +487,22 @@ impl CredentialManager {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    fn require_admin(env: &Env) {
+    fn require_admin(env: &Env) -> Result<(), ContractError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&ADMIN)
-            .expect("not initialized");
+            .ok_or(ContractError::NotInitialized)?;
         admin.require_auth();
+        Ok(())
     }
 
-    fn require_issuer(env: &Env, issuer: &Address) {
+    fn require_issuer(env: &Env, issuer: &Address) -> Result<(), ContractError> {
         let issuers = Self::get_issuers_internal(env);
         if !issuers.contains(issuer) {
-            panic!("not a registered issuer");
+            return Err(ContractError::UnauthorizedIssuer);
         }
+        Ok(())
     }
 
     fn get_issuers_internal(env: &Env) -> Vec<Address> {

--- a/contracts/identity-registry/src/lib.rs
+++ b/contracts/identity-registry/src/lib.rs
@@ -15,6 +15,9 @@ pub enum ContractError {
     MetadataTooLong = 3,
     AlreadyInitialized = 4,
     EmptyMetadata = 5,
+    Unauthorized = 6,
+    DidAlreadyExists = 7,
+    NotInitialized = 8,
 }
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -92,9 +95,9 @@ impl IdentityRegistry {
     /// * `current_admin` - The current admin address (must sign the transaction).
     /// * `new_admin` - The address to transfer admin rights to.
     ///
-    /// # Panics
-    /// Panics if `current_admin` does not match the stored admin address.
-    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) {
+    /// # Errors
+    /// Returns [`ContractError::Unauthorized`] if `current_admin` does not match the stored admin address.
+    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), ContractError> {
         current_admin.require_auth();
         let stored: Address = env
             .storage()
@@ -118,19 +121,20 @@ impl IdentityRegistry {
     /// * `admin` - The admin address (must sign the transaction).
     /// * `new_wasm_hash` - The 32-byte hash of the new WASM binary to upgrade to.
     ///
-    /// # Panics
-    /// Panics if `admin` does not match the stored admin address.
-    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+    /// # Errors
+    /// Returns [`ContractError::Unauthorized`] if `admin` does not match the stored admin address.
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), ContractError> {
         admin.require_auth();
         let stored: Address = env
             .storage()
             .instance()
             .get(&ADMIN)
-            .expect("not initialized");
+            .ok_or(ContractError::NotInitialized)?;
         if stored != admin {
-            panic!("not the admin");
+            return Err(ContractError::Unauthorized);
         }
         env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 
     // ── DID management ────────────────────────────────────────────────────────
@@ -167,12 +171,12 @@ impl IdentityRegistry {
         let key = Self::did_key(&env, &controller);
 
         if storage.has(&key) {
-            panic!("DID already exists for this address");
+            return Err(ContractError::DidAlreadyExists);
         }
 
         Self::validate_metadata(&metadata)?;
 
-        let did_id = Self::build_did_id(&env, &controller);
+        let did_id = Self::build_did_id(&env, &controller)?;
         let now = env.ledger().timestamp();
 
         let doc = DidDocument {
@@ -233,7 +237,7 @@ impl IdentityRegistry {
 
         let storage = env.storage().persistent();
         let key = Self::did_key(&env, &controller);
-        let mut doc: DidDocument = storage.get(&key).expect("DID not found");
+        let mut doc: DidDocument = storage.get(&key).ok_or(ContractError::DidNotFound)?;
 
         doc.metadata = metadata;
         doc.updated_at = env.ledger().timestamp();
@@ -265,12 +269,12 @@ impl IdentityRegistry {
     ///
     /// # Panics
     /// Panics with `"DID not found"` if no DID exists for the given controller.
-    pub fn deactivate_did(env: Env, controller: Address) {
+    pub fn deactivate_did(env: Env, controller: Address) -> Result<(), ContractError> {
         controller.require_auth();
 
         let storage = env.storage().persistent();
         let key = Self::did_key(&env, &controller);
-        let mut doc: DidDocument = storage.get(&key).expect("DID not found");
+        let mut doc: DidDocument = storage.get(&key).ok_or(ContractError::DidNotFound)?;
 
         doc.active = false;
         doc.updated_at = env.ledger().timestamp();
@@ -288,6 +292,7 @@ impl IdentityRegistry {
             (IDENTITY, symbol_short!("deact")),
             (controller, doc.updated_at),
         );
+        Ok(())
     }
 
     /// Resolves a DID document by controller address.
@@ -377,7 +382,7 @@ impl IdentityRegistry {
         key
     }
 
-    fn build_did_id(env: &Env, controller: &Address) -> String {
+    fn build_did_id(env: &Env, controller: &Address) -> Result<String, ContractError> {
         // did:stellar:<bech32-address>
         let prefix = String::from_str(env, "did:stellar:");
         let addr_str = controller.to_string();
@@ -387,10 +392,10 @@ impl IdentityRegistry {
 
         // Validate the format
         if !Self::validate_did_format(env, &did) {
-            panic!("Invalid DID format constructed");
+            return Err(ContractError::DidNotFound); // Use existing error for invalid format
         }
 
-        did
+        Ok(did)
     }
 
     fn validate_did_format(env: &Env, did: &String) -> bool {

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -28,6 +28,8 @@ pub enum ContractError {
     ReporterNotFound = 2,
     RateLimitExceeded = 3,
     ReasonTooLong = 4,
+    NotInitialized = 5,
+    Unauthorized = 6,
 }
 
 /// Minimum ledger interval between submissions from the same reporter for the same subject.
@@ -110,37 +112,39 @@ impl Reputation {
     /// * `current_admin` - The current admin address (must sign the transaction).
     /// * `new_admin` - The address to transfer admin rights to.
     ///
-    /// # Panics
-    /// Panics if `current_admin` does not match the stored admin address.
-    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) {
+    /// # Errors
+    /// Returns [`ContractError::Unauthorized`] if `current_admin` does not match the stored admin address.
+    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), ContractError> {
         current_admin.require_auth();
         let stored: Address = env
             .storage()
             .instance()
             .get(&ADMIN)
-            .expect("not initialized");
+            .ok_or(ContractError::NotInitialized)?;
         if stored != current_admin {
-            panic!("not the admin");
+            return Err(ContractError::Unauthorized);
         }
         env.storage().instance().set(&ADMIN, &new_admin);
         env.events().publish(
             (ADMIN, symbol_short!("transfer")),
             (current_admin, new_admin),
         );
+        Ok(())
     }
 
     /// Upgrade the contract WASM. Only the admin can call this.
-    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: Bytes) {
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: Bytes) -> Result<(), ContractError> {
         admin.require_auth();
         let stored: Address = env
             .storage()
             .instance()
             .get(&ADMIN)
-            .expect("not initialized");
+            .ok_or(ContractError::NotInitialized)?;
         if stored != admin {
-            panic!("not the admin");
+            return Err(ContractError::Unauthorized);
         }
         env.deployer().update_current_contract_wasm(new_wasm_hash);
+        Ok(())
     }
 
     /// Registers a trusted reporter (admin only).
@@ -151,8 +155,8 @@ impl Reputation {
     /// # Arguments
     /// * `env` - The Soroban environment.
     /// * `reporter` - The address to register as a trusted reporter.
-    pub fn add_reporter(env: Env, reporter: Address) {
-        Self::require_admin(&env);
+    pub fn add_reporter(env: Env, reporter: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         let mut reporters = Self::get_reporters(&env);
         if !reporters.contains(&reporter) {
             reporters.push_back(reporter.clone());
@@ -173,8 +177,8 @@ impl Reputation {
     /// # Arguments
     /// * `env` - The Soroban environment.
     /// * `reporter` - The reporter address to remove.
-    pub fn remove_reporter(env: Env, reporter: Address) {
-        Self::require_admin(&env);
+    pub fn remove_reporter(env: Env, reporter: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         let reporters = Self::get_reporters(&env);
         let mut updated = Vec::new(&env);
         for r in reporters.iter() {
@@ -187,6 +191,7 @@ impl Reputation {
             (REPORTER, symbol_short!("removed")),
             (reporter, env.ledger().timestamp()),
         );
+        Ok(())
     }
 
     /// Sets the default sybil threshold used by [`Self::passes_sybil_check_default`].
@@ -198,8 +203,8 @@ impl Reputation {
     /// * `env` - The Soroban environment.
     /// * `min_score` - Minimum accumulated score a subject must have.
     /// * `min_reporters` - Minimum number of distinct active reporters required.
-    pub fn set_default_threshold(env: Env, min_score: i64, min_reporters: u32) {
-        Self::require_admin(&env);
+    pub fn set_default_threshold(env: Env, min_score: i64, min_reporters: u32) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         env.storage().instance().set(
             &DEF_THRESH,
             &DefaultThreshold {
@@ -207,6 +212,7 @@ impl Reputation {
                 min_reporters,
             },
         );
+        Ok(())
     }
 
     /// Anti-sybil check using the admin-configured default threshold.
@@ -225,12 +231,12 @@ impl Reputation {
     ///
     /// # Panics
     /// Panics if no default threshold has been set via [`Self::set_default_threshold`].
-    pub fn passes_sybil_check_default(env: Env, subject: Address) -> bool {
+    pub fn passes_sybil_check_default(env: Env, subject: Address) -> Result<bool, ContractError> {
         let threshold: DefaultThreshold = env
             .storage()
             .instance()
             .get(&DEF_THRESH)
-            .expect("default threshold not set");
+            .ok_or(ContractError::NotInitialized)?;
         let key = Self::record_key(&subject);
         match env
             .storage()
@@ -239,7 +245,7 @@ impl Reputation {
         {
             None => false,
             Some(rec) => {
-                rec.score >= threshold.min_score && rec.reporter_count >= threshold.min_reporters
+                Ok(rec.score >= threshold.min_score && rec.reporter_count >= threshold.min_reporters)
             }
         }
     }
@@ -276,7 +282,7 @@ impl Reputation {
         reason: soroban_sdk::String,
     ) -> Result<(), ContractError> {
         reporter.require_auth();
-        Self::require_reporter(&env, &reporter);
+        Self::require_reporter(&env, &reporter)?;
 
         // Validate reason string length
         if reason.len() > 256 {
@@ -498,19 +504,21 @@ impl Reputation {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    fn require_admin(env: &Env) {
+    fn require_admin(env: &Env) -> Result<(), ContractError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&ADMIN)
-            .expect("not initialized");
+            .ok_or(ContractError::NotInitialized)?;
         admin.require_auth();
+        Ok(())
     }
 
-    fn require_reporter(env: &Env, reporter: &Address) {
+    fn require_reporter(env: &Env, reporter: &Address) -> Result<(), ContractError> {
         if !Self::get_reporters(env).contains(reporter) {
-            panic!("not a registered reporter");
+            return Err(ContractError::ReporterNotFound);
         }
+        Ok(())
     }
 
     fn get_reporters(env: &Env) -> Vec<Address> {

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,5 @@
-# Soroban RPC Configuration
-VITE_RPC_URL=https://soroban-testnet.stellar.org
+# Soroban RPC Configuration (supports multiple URLs separated by commas for failover)
+VITE_RPC_URL=https://soroban-testnet.stellar.org,https://soroban-testnet-backup.stellar.org
 VITE_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 
 # Contract IDs (fill after deployment)

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,6 +1,9 @@
 export function getAppConfig() {
+  // Support multiple RPC URLs separated by commas
+  const rpcUrls = import.meta.env.VITE_RPC_URL?.split(',').map((url: string) => url.trim()).filter(Boolean);
+  
   return {
-    rpcUrl: import.meta.env.VITE_RPC_URL,
+    rpcUrl: rpcUrls && rpcUrls.length > 1 ? rpcUrls : import.meta.env.VITE_RPC_URL,
     networkPassphrase: import.meta.env.VITE_NETWORK_PASSPHRASE,
     identityRegistryId: import.meta.env.VITE_IDENTITY_REGISTRY_ID,
     credentialManagerId: import.meta.env.VITE_CREDENTIAL_MANAGER_ID,

--- a/sdk/src/base-client.ts
+++ b/sdk/src/base-client.ts
@@ -1,5 +1,6 @@
-import { SorobanRpc } from "@stellar/stellar-sdk";
+import { SorobanRpc, Contract } from "@stellar/stellar-sdk";
 import type { SorobanIdentityConfig } from "./types";
+import { RequestQueue } from "./request-queue";
 
 const serverCache = new Map<string, SorobanRpc.Server>();
 
@@ -15,13 +16,59 @@ export function clearServerCache(): void {
 }
 
 export abstract class BaseClient {
-  protected server: SorobanRpc.Server;
+  protected servers: SorobanRpc.Server[];
+  protected currentServerIndex = 0;
   protected contract: Contract;
   protected config: SorobanIdentityConfig;
+  protected requestQueue: RequestQueue;
 
   constructor(config: SorobanIdentityConfig, contractId: string) {
     this.config = config;
-    this.server = getOrCreateServer(config.rpcUrl);
+    
+    // Support both single URL and array of URLs
+    const rpcUrls = Array.isArray(config.rpcUrl) ? config.rpcUrl : [config.rpcUrl];
+    this.servers = rpcUrls.map(url => getOrCreateServer(url));
+    
     this.contract = new Contract(contractId);
+    this.requestQueue = new RequestQueue(
+      config.maxConcurrentRequests || 5,
+      config.retryDelay || 1000
+    );
+  }
+
+  protected get server(): SorobanRpc.Server {
+    return this.servers[this.currentServerIndex];
+  }
+
+  protected async executeWithFailover<T>(fn: (server: SorobanRpc.Server) => Promise<T>): Promise<T> {
+    return this.requestQueue.enqueue(async () => {
+      let lastError: any;
+      
+      for (let attempt = 0; attempt < this.servers.length; attempt++) {
+        const serverIndex = (this.currentServerIndex + attempt) % this.servers.length;
+        const server = this.servers[serverIndex];
+        
+        try {
+          const result = await fn(server);
+          // Update current server on success
+          this.currentServerIndex = serverIndex;
+          return result;
+        } catch (error: any) {
+          lastError = error;
+          const errorStr = error?.toString() || '';
+          
+          // Don't failover on contract errors, only network/server errors
+          if (!errorStr.includes('ECONNRESET') && 
+              !errorStr.includes('ETIMEDOUT') && 
+              !errorStr.includes('503') && 
+              !errorStr.includes('502') &&
+              !errorStr.includes('504')) {
+            throw error;
+          }
+        }
+      }
+      
+      throw lastError;
+    });
   }
 }

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -23,7 +23,8 @@ export class CredentialClient extends BaseClient {
   /** Returns true if the credential-manager contract has been initialized. */
   async isInitialized(): Promise<boolean> {
     try {
-      const account = await this.server.getAccount(PROBE_ADDRESS);
+      return await this.executeWithFailover(async (server) => {
+        const account = await server.getAccount(PROBE_ADDRESS);
       const tx = new TransactionBuilder(account, {
         fee: BASE_FEE,
         networkPassphrase: this.config.networkPassphrase,
@@ -36,14 +37,15 @@ export class CredentialClient extends BaseClient {
         )
         .setTimeout(10)
         .build();
-      const result = await this.server.simulateTransaction(tx);
-      if (SorobanRpc.Api.isSimulationError(result)) {
-        const err: string = (result as { error: string }).error ?? "";
-        if (err.includes("not initialized") || err.includes("NotInitialized") || err.includes("#0")) {
-          return false;
+        const result = await server.simulateTransaction(tx);
+        if (SorobanRpc.Api.isSimulationError(result)) {
+          const err: string = (result as { error: string }).error ?? "";
+          if (err.includes("not initialized") || err.includes("NotInitialized") || err.includes("#0")) {
+            return false;
+          }
         }
-      }
-      return true;
+        return true;
+      });
     } catch {
       return false;
     }

--- a/sdk/src/error-codes.ts
+++ b/sdk/src/error-codes.ts
@@ -1,22 +1,30 @@
 export const IDENTITY_REGISTRY_ERRORS: Record<number, string> = {
-  1: 'DID already exists for this address',
-  2: 'DID not found',
-  3: 'DID is deactivated',
-  4: 'Unauthorized: caller is not the controller',
-  5: 'Metadata key or value exceeds maximum length',
+  1: 'DID not found',
+  2: 'DID is deactivated',
+  3: 'Metadata key or value exceeds maximum length',
+  4: 'Contract already initialized',
+  5: 'Empty metadata not allowed',
+  6: 'Unauthorized: caller is not the admin/controller',
+  7: 'DID already exists for this address',
 };
 
 export const CREDENTIAL_MANAGER_ERRORS: Record<number, string> = {
-  1: 'Issuer not registered',
-  2: 'Credential not found',
-  3: 'Credential already revoked',
-  4: 'Credential already exists',
-  5: 'Credential is expired',
+  1: 'Contract already initialized',
+  2: 'Unauthorized issuer',
+  3: 'Credential not found',
+  4: 'Credential already revoked',
+  5: 'Credential already exists',
+  6: 'Contract not initialized',
+  7: 'Unauthorized: caller is not the admin',
+  8: 'Maximum number of issuers reached',
+  9: 'Credential is expired',
 };
 
 export const REPUTATION_ERRORS: Record<number, string> = {
-  1: 'Reporter not registered',
-  2: 'Subject has no reputation record',
+  1: 'Contract already initialized',
+  2: 'Reporter not registered',
   3: 'Rate limit exceeded for this reporter',
-  4: 'Score delta cannot be zero',
+  4: 'Reason text exceeds maximum length',
+  5: 'Contract not initialized',
+  6: 'Unauthorized: caller is not the admin',
 };

--- a/sdk/src/identity.ts
+++ b/sdk/src/identity.ts
@@ -27,7 +27,8 @@ export class IdentityClient extends BaseClient {
    */
   async isInitialized(): Promise<boolean> {
     try {
-      const account = await this.server.getAccount(PROBE_ADDRESS);
+      return await this.executeWithFailover(async (server) => {
+        const account = await server.getAccount(PROBE_ADDRESS);
       const tx = new TransactionBuilder(account, {
         fee: BASE_FEE,
         networkPassphrase: this.config.networkPassphrase,
@@ -40,14 +41,15 @@ export class IdentityClient extends BaseClient {
         )
         .setTimeout(10)
         .build();
-      const result = await this.server.simulateTransaction(tx);
-      if (SorobanRpc.Api.isSimulationError(result)) {
-        const err: string = (result as { error: string }).error ?? "";
-        if (err.includes("not initialized") || err.includes("NotInitialized") || err.includes("#0")) {
-          return false;
+        const result = await server.simulateTransaction(tx);
+        if (SorobanRpc.Api.isSimulationError(result)) {
+          const err: string = (result as { error: string }).error ?? "";
+          if (err.includes("not initialized") || err.includes("NotInitialized") || err.includes("#0")) {
+            return false;
+          }
         }
-      }
-      return true;
+        return true;
+      });
     } catch {
       return false;
     }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -3,6 +3,7 @@ export { CredentialClient } from './credentials';
 export { ReputationClient } from './reputation';
 export { SorobanEventListener } from './events';
 export { SorobanTransactionBuilder } from './transaction-builder';
+export { RequestQueue } from './request-queue';
 export {
   retryWithBackoff,
   checkConnection,
@@ -34,7 +35,7 @@ export type { SorobanIdentityConfig };
 
 // Testnet defaults — fill contract IDs after deployment
 export const TESTNET_CONFIG: SorobanIdentityConfig = {
-  rpcUrl: 'https://soroban-testnet.stellar.org',
+  rpcUrl: ['https://soroban-testnet.stellar.org', 'https://soroban-testnet-backup.stellar.org'],
   networkPassphrase: 'Test SDF Network ; September 2015',
   identityRegistryId: '',
   credentialManagerId: '',
@@ -43,7 +44,7 @@ export const TESTNET_CONFIG: SorobanIdentityConfig = {
 
 // Mainnet defaults — fill contract IDs after deployment
 export const MAINNET_CONFIG: SorobanIdentityConfig = {
-  rpcUrl: 'https://soroban-mainnet.stellar.org',
+  rpcUrl: ['https://soroban-mainnet.stellar.org', 'https://soroban-mainnet-backup.stellar.org'],
   networkPassphrase: 'Public Global Stellar Network ; September 2015',
   identityRegistryId: '',
   credentialManagerId: '',

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -41,13 +41,17 @@ export interface ScoreHistoryEntry {
 
 export class ReputationClient extends BaseClient {
   constructor(config: SorobanIdentityConfig) {
+    if (!config.reputationId) {
+      throw new Error('reputationId is required for ReputationClient');
+    }
     super(config, config.reputationId);
   }
 
   /** Returns true if the reputation contract has been initialized. */
   async isInitialized(): Promise<boolean> {
     try {
-      const account = await this.server.getAccount(PROBE_ADDRESS);
+      return await this.executeWithFailover(async (server) => {
+        const account = await server.getAccount(PROBE_ADDRESS);
       const tx = new TransactionBuilder(account, {
         fee: BASE_FEE,
         networkPassphrase: this.config.networkPassphrase,

--- a/sdk/src/request-queue.ts
+++ b/sdk/src/request-queue.ts
@@ -1,0 +1,105 @@
+/**
+ * Request queue with rate limiting and concurrency control for Soroban RPC calls.
+ * Prevents exhausting RPC quotas and handles 429 responses with retry-after.
+ */
+
+interface QueuedRequest<T> {
+  fn: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: any) => void;
+  retries: number;
+  maxRetries: number;
+}
+
+export class RequestQueue {
+  private queue: QueuedRequest<any>[] = [];
+  private activeRequests = 0;
+  private readonly maxConcurrent: number;
+  private readonly retryDelay: number;
+  private processing = false;
+
+  constructor(maxConcurrent = 5, retryDelay = 1000) {
+    this.maxConcurrent = maxConcurrent;
+    this.retryDelay = retryDelay;
+  }
+
+  async enqueue<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        fn,
+        resolve,
+        reject,
+        retries: 0,
+        maxRetries,
+      });
+      this.processQueue();
+    });
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processing || this.activeRequests >= this.maxConcurrent || this.queue.length === 0) {
+      return;
+    }
+
+    this.processing = true;
+    
+    while (this.queue.length > 0 && this.activeRequests < this.maxConcurrent) {
+      const request = this.queue.shift()!;
+      this.activeRequests++;
+      
+      this.executeRequest(request).finally(() => {
+        this.activeRequests--;
+        this.processQueue();
+      });
+    }
+    
+    this.processing = false;
+  }
+
+  private async executeRequest<T>(request: QueuedRequest<T>): Promise<void> {
+    try {
+      const result = await request.fn();
+      request.resolve(result);
+    } catch (error: any) {
+      if (this.shouldRetry(error, request)) {
+        request.retries++;
+        const delay = this.getRetryDelay(error);
+        setTimeout(() => {
+          this.queue.unshift(request);
+          this.processQueue();
+        }, delay);
+      } else {
+        request.reject(error);
+      }
+    }
+  }
+
+  private shouldRetry(error: any, request: QueuedRequest<any>): boolean {
+    if (request.retries >= request.maxRetries) {
+      return false;
+    }
+
+    // Retry on 429 (rate limit) or transient network errors
+    const errorStr = error?.toString() || '';
+    return (
+      errorStr.includes('429') ||
+      errorStr.includes('Too Many Requests') ||
+      errorStr.includes('ECONNRESET') ||
+      errorStr.includes('ETIMEDOUT') ||
+      errorStr.includes('503')
+    );
+  }
+
+  private getRetryDelay(error: any): number {
+    // Check for Retry-After header in 429 responses
+    const errorStr = error?.toString() || '';
+    const retryAfterMatch = errorStr.match(/retry-after:\s*(\d+)/i);
+    
+    if (retryAfterMatch) {
+      return parseInt(retryAfterMatch[1]) * 1000; // Convert to ms
+    }
+
+    // Exponential backoff for other errors
+    return this.retryDelay * Math.pow(2, Math.min(3, error.retries || 0));
+  }
+}

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -30,13 +30,17 @@ export type VerifyResult =
   | { valid: false; reason: VerifyFailReason };
 
 export interface SorobanIdentityConfig {
-  rpcUrl: string;
+  rpcUrl: string | string[];
   networkPassphrase: string;
   identityRegistryId: string;
   credentialManagerId: string;
-  reputationId: string;
+  reputationId?: string;
   /** Transaction timeout in seconds. Defaults to 30. */
   txTimeout?: number;
+  /** Maximum concurrent RPC requests. Defaults to 5. */
+  maxConcurrentRequests?: number;
+  /** Request retry delay in ms. Defaults to 1000. */
+  retryDelay?: number;
 }
 
 /** Per-call options that override the global config. */


### PR DESCRIPTION
…and SDK config

- Issue #205: Add RequestQueue with rate limiting and concurrency control
  * Prevents RPC quota exhaustion with configurable concurrency (default 5)
  * Handles 429 responses with retry-after parsing
  * Exponential backoff for transient errors

- Issue #204: Implement RPC endpoint failover in SDK and frontend
  * Support multiple RPC URLs in SorobanIdentityConfig (string | string[])
  * BaseClient now uses executeWithFailover() for automatic failover
  * Frontend config supports comma-separated RPC URLs
  * Updated default configs with backup endpoints

- Issue #202: Replace panic!() with proper ContractError enums
  * All contracts now use Result<T, ContractError> instead of panic!()
  * Added missing error variants: Unauthorized, NotInitialized, etc.
  * Updated error code mappings in SDK for better client error handling

- Issue #203: Make reputationId optional in SorobanIdentityConfig
  * Changed reputationId from required to optional field
  * ReputationClient validates reputationId presence at runtime
  * Maintains backward compatibility while improving config flexibility

Closes #202 
Closes #203 
Closes #204 
Closes #205