### PR TITLE
feat: add W3C-compliant JSON-LD export for DID documents

### DIFF
--- a/frontend/src/components/IdentityPanel.tsx
+++ b/frontend/src/components/IdentityPanel.tsx
@@ -9,6 +9,7 @@ import SkeletonCard from './SkeletonCard';
 import ReputationChart from './ReputationChart';
 import { formatTimestamp } from '../utils/formatDate';
 import { useWalletContext } from '../context/WalletContext';
+import { exportDidDocumentAsJsonLd } from '../../../sdk/src/serializers';
 
 type IdentityState =
   | { status: 'idle' }
@@ -133,6 +134,17 @@ export default function IdentityPanel() {
     const a = document.createElement('a');
     a.href = url;
     a.download = 'did-document.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportJsonLd = () => {
+    if (!resolvedDoc) return;
+    const blob = new Blob([exportDidDocumentAsJsonLd(resolvedDoc)], { type: 'application/ld+json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'did-document.jsonld';
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -352,6 +364,13 @@ export default function IdentityPanel() {
               style={{ marginLeft: '0.5rem' }}
             >
               Export JSON
+            </button>
+            <button
+              onClick={handleExportJsonLd}
+              disabled={!resolvedDoc}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              Export JSON-LD
             </button>
             {showQr && (
               <div style={{ marginTop: '0.75rem', display: 'inline-block', background: '#fff', padding: '0.5rem', borderRadius: '0.5rem' }}>

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -16,6 +16,7 @@ export {
   REPUTATION_ERRORS,
 } from './error-codes';
 export { clearServerCache } from './base-client';
+export { toW3CDidDocument, exportDidDocumentAsJsonLd } from './serializers';
 export type {
   DidDocument,
   Credential,

--- a/sdk/src/serializers.test.ts
+++ b/sdk/src/serializers.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { toW3CDidDocument, exportDidDocumentAsJsonLd } from './serializers';
+import type { DidDocument } from './types';
+
+const mockDoc: DidDocument = {
+  id: 'did:stellar:GABC1234567890',
+  controller: 'GABC1234567890',
+  metadata: { website: 'https://example.com', twitter: 'https://twitter.com/example' },
+  createdAt: 1000000,
+  updatedAt: 1000001,
+  active: true,
+};
+
+describe('toW3CDidDocument', () => {
+  it('includes the W3C DID context', () => {
+    const result = toW3CDidDocument(mockDoc) as any;
+    expect(result['@context']).toEqual(['https://www.w3.org/ns/did/v1']);
+  });
+
+  it('sets id from doc.id', () => {
+    const result = toW3CDidDocument(mockDoc) as any;
+    expect(result.id).toBe('did:stellar:GABC1234567890');
+  });
+
+  it('sets controller from doc.controller', () => {
+    const result = toW3CDidDocument(mockDoc) as any;
+    expect(result.controller).toBe('GABC1234567890');
+  });
+
+  it('maps metadata entries to service array', () => {
+    const result = toW3CDidDocument(mockDoc) as any;
+    expect(result.service).toHaveLength(2);
+    expect(result.service[0]).toMatchObject({
+      id: 'did:stellar:GABC1234567890#website',
+      type: 'LinkedDomains',
+      serviceEndpoint: 'https://example.com',
+    });
+  });
+
+  it('produces empty service array when metadata is empty', () => {
+    const doc = { ...mockDoc, metadata: {} };
+    const result = toW3CDidDocument(doc) as any;
+    expect(result.service).toEqual([]);
+  });
+
+  it('includes an empty verificationMethod array', () => {
+    const result = toW3CDidDocument(mockDoc) as any;
+    expect(result.verificationMethod).toEqual([]);
+  });
+});
+
+describe('exportDidDocumentAsJsonLd', () => {
+  it('returns a valid JSON string', () => {
+    const output = exportDidDocumentAsJsonLd(mockDoc);
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it('parsed output contains @context field', () => {
+    const parsed = JSON.parse(exportDidDocumentAsJsonLd(mockDoc));
+    expect(parsed['@context']).toEqual(['https://www.w3.org/ns/did/v1']);
+  });
+
+  it('parsed output contains correct id', () => {
+    const parsed = JSON.parse(exportDidDocumentAsJsonLd(mockDoc));
+    expect(parsed.id).toBe('did:stellar:GABC1234567890');
+  });
+
+  it('parsed output contains correct controller', () => {
+    const parsed = JSON.parse(exportDidDocumentAsJsonLd(mockDoc));
+    expect(parsed.controller).toBe('GABC1234567890');
+  });
+
+  it('output is pretty-printed with 2-space indent', () => {
+    const output = exportDidDocumentAsJsonLd(mockDoc);
+    expect(output).toContain('\n  ');
+  });
+});

--- a/sdk/src/serializers.ts
+++ b/sdk/src/serializers.ts
@@ -1,0 +1,19 @@
+import type { DidDocument } from './types';
+
+export function toW3CDidDocument(doc: DidDocument): object {
+  return {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id: doc.id,
+    controller: doc.controller,
+    verificationMethod: [],
+    service: Object.entries(doc.metadata).map(([id, serviceEndpoint]) => ({
+      id: `${doc.id}#${id}`,
+      type: 'LinkedDomains',
+      serviceEndpoint,
+    })),
+  };
+}
+
+export function exportDidDocumentAsJsonLd(doc: DidDocument): string {
+  return JSON.stringify(toW3CDidDocument(doc), null, 2);
+}


### PR DESCRIPTION
Closes #160, Closes #161

## What was done

Both issues (#160 and #161) requested the same feature: a utility to serialize the SDK's DidDocument object into the W3C DID Core JSON-LD format, which is required for interoperability with external DID resolvers, identity wallets, and verifiers.

## How it was implemented

### 1. sdk/src/serializers.ts (new file)
Created a dedicated serializers module with two exported functions:

- toW3CDidDocument(doc: DidDocument): object Converts a raw DidDocument into a plain W3C-compliant object with:
    - '@context': ['https://www.w3.org/ns/did/v1']
    - id: taken directly from doc.id (already in did:stellar:<addr> form)
    - controller: the Stellar address from doc.controller
    - verificationMethod: [] (empty array, ready for future key material)
    - service: each metadata key-value pair mapped to a LinkedDomains service entry with id '<did>#<key>', type 'LinkedDomains', and serviceEndpoint set to the metadata value

- exportDidDocumentAsJsonLd(doc: DidDocument): string Thin wrapper that calls toW3CDidDocument and returns the result as a pretty-printed JSON string (2-space indent), suitable for file download or transmission.

### 2. sdk/src/index.ts
Added a named re-export of both functions so consumers of the SDK can import them directly:
  import { toW3CDidDocument, exportDidDocumentAsJsonLd } from '@soroban-identity/sdk';

### 3. frontend/src/components/IdentityPanel.tsx
- Imported exportDidDocumentAsJsonLd from the serializers module.
- Added handleExportJsonLd(): creates a Blob with MIME type 'application/ld+json', triggers a browser download of the file as 'did-document.jsonld'.
- Added an 'Export JSON-LD' button rendered alongside the existing 'Export JSON' button, disabled when no DID document is resolved.

### 4. sdk/src/serializers.test.ts (new file)
Added 11 unit tests using Vitest covering:
  - toW3CDidDocument: @context presence, id, controller, service mapping from metadata, empty service when metadata is empty, verificationMethod
  - exportDidDocumentAsJsonLd: valid JSON output, @context field, id field, controller field, pretty-print formatting