### PR TITLE
fix: CSP headers, env vars, secret key security, and event indexing utility

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,6 @@ import {
   type NetworkName,
 } from "./network";
 import { checkConnection, IdentityClient, CredentialClient, ReputationClient } from "../../sdk/src/index";
-import { getAppConfig } from "./config";
 import type { Credential } from "../../sdk/src/types";
 
 type Tab = "identity" | "credentials";
@@ -63,8 +62,10 @@ export default function App() {
   // Check RPC connection health on load
   useEffect(() => {
     const checkRpcHealth = async () => {
-      const config = getAppConfig();
-      const server = new SorobanRpc.Server(config.rpcUrl);
+      const rpcUrl = Array.isArray(networkConfig.rpcUrl)
+        ? networkConfig.rpcUrl[0]
+        : networkConfig.rpcUrl;
+      const server = new SorobanRpc.Server(rpcUrl);
       const healthy = await checkConnection(server);
       setIsConnected(healthy);
     };
@@ -74,10 +75,9 @@ export default function App() {
   // Check contract initialization on load
   useEffect(() => {
     const checkInit = async () => {
-      const config = getAppConfig();
-      const identity = new IdentityClient(config);
-      const credentials = new CredentialClient(config);
-      const reputation = new ReputationClient(config);
+      const identity = new IdentityClient(networkConfig);
+      const credentials = new CredentialClient(networkConfig);
+      const reputation = new ReputationClient(networkConfig);
       const [idOk, credOk, repOk] = await Promise.all([
         identity.isInitialized(),
         credentials.isInitialized(),

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,12 +1,7 @@
+import { getNetworkConfig } from './network';
+
+// Returns config for the active network, resolved from VITE_NETWORK / VITE_*_RPC_URL
+// / VITE_*_IDENTITY_REGISTRY_ID env vars defined in .env.example.
 export function getAppConfig() {
-  // Support multiple RPC URLs separated by commas
-  const rpcUrls = import.meta.env.VITE_RPC_URL?.split(',').map((url: string) => url.trim()).filter(Boolean);
-  
-  return {
-    rpcUrl: rpcUrls && rpcUrls.length > 1 ? rpcUrls : import.meta.env.VITE_RPC_URL,
-    networkPassphrase: import.meta.env.VITE_NETWORK_PASSPHRASE,
-    identityRegistryId: import.meta.env.VITE_IDENTITY_REGISTRY_ID,
-    credentialManagerId: import.meta.env.VITE_CREDENTIAL_MANAGER_ID,
-    reputationId: import.meta.env.VITE_REPUTATION_ID,
-  };
+  return getNetworkConfig();
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,45 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const ALLOWED_RPC_ORIGINS = [
+  "https://soroban-testnet.stellar.org",
+  "https://soroban-mainnet.stellar.org",
+  "https://soroban-testnet-backup.stellar.org",
+  "https://soroban-mainnet-backup.stellar.org",
+].join(" ");
+
+// unsafe-inline / unsafe-eval are required by Vite's dev and preview servers.
+// For production hosting platforms (Vercel, Netlify, Caddy, nginx) replace
+// these with a nonce-based policy and set headers at the edge instead.
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  `connect-src 'self' ${ALLOWED_RPC_ORIGINS} wss://relay.walletconnect.com`,
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+const SECURITY_HEADERS = {
+  "Content-Security-Policy": CSP,
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+};
+
 export default defineConfig({
   plugins: [react()],
   define: {
     global: "globalThis",
+  },
+  server: {
+    headers: SECURITY_HEADERS,
+  },
+  preview: {
+    headers: SECURITY_HEADERS,
   },
 });

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -38,7 +38,49 @@ case "$NETWORK" in
     ;;
 esac
 
-SOURCE_ACCOUNT="${STELLAR_SECRET_KEY:?Set STELLAR_SECRET_KEY}"
+# ─── Secret key security checks ─────────────────────────────────────────────
+# STELLAR_SECRET_KEY should always be injected by a secrets manager, never
+# typed into an interactive shell or stored in a .env file committed to git.
+#
+# Recommended approaches:
+#   GitHub Actions : store as a repository secret; access via ${{ secrets.STELLAR_SECRET_KEY }}
+#   AWS            : aws secretsmanager get-secret-value --secret-id stellar/deploy-key --query SecretString --output text
+#   HashiCorp Vault: vault kv get -field=key secret/stellar
+#   1Password CLI  : op read "op://vault/stellar-deploy/key"
+#
+# For mainnet deployments, strongly consider hardware wallet signing
+# (Ledger via stellar-hd-wallet) to avoid exposing the raw key at all.
+
+if [[ -z "${STELLAR_SECRET_KEY:-}" ]]; then
+  echo "Error: STELLAR_SECRET_KEY is not set."
+  echo "  Inject it from a secrets manager — do not paste it into your shell."
+  exit 1
+fi
+
+# Warn when shell history is recording (key may end up in ~/.bash_history etc.)
+if [[ -n "${HISTFILE:-}" ]] && [[ "${HISTCONTROL:-}" != *ignorespace* ]]; then
+  echo "WARNING: Shell history is active. If you exported STELLAR_SECRET_KEY in"
+  echo "         this terminal the raw key may be saved to: ${HISTFILE}"
+  echo "         Prefix the export with a space (HISTCONTROL=ignorespace) or use"
+  echo "         a secrets manager to avoid this."
+  echo ""
+fi
+
+# Extra gate for mainnet: require explicit acknowledgement and add a delay so
+# accidental runs can be aborted before any irreversible action is taken.
+if [[ "$NETWORK" == "mainnet" ]]; then
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "  WARNING: Deploying to MAINNET with a live secret key."
+  echo "  Verify that STELLAR_SECRET_KEY was injected from a"
+  echo "  secrets manager and is NOT present in CI logs, shell"
+  echo "  history, or any committed file."
+  echo "  Press Ctrl+C within 10 seconds to abort."
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo ""
+  sleep 10
+fi
+
+SOURCE_ACCOUNT="$STELLAR_SECRET_KEY"
 
 # Retry configuration with exponential backoff
 MAX_RETRIES="${MAX_RETRIES:-3}"

--- a/sdk/src/events.ts
+++ b/sdk/src/events.ts
@@ -14,6 +14,75 @@ export interface ContractEvent {
   txHash: string;
 }
 
+export interface GetEventsOptions {
+  rpcUrl: string;
+  contractId: string;
+  /** Ledger to start scanning from. Omit to start from the oldest available. */
+  startLedger?: number;
+  /** Maximum number of events to return. Defaults to 100. */
+  limit?: number;
+  filter?: EventFilter;
+}
+
+/**
+ * One-shot fetch of historical contract events via the Soroban RPC getEvents
+ * endpoint. For real-time updates use SorobanEventListener instead.
+ *
+ * Event indexing strategy:
+ *   - For lightweight queries: call this utility with a known startLedger.
+ *   - For production indexing: consider the Mercury indexer for Soroban
+ *     (https://mercurydata.app) or run a custom listener that checkpoints
+ *     the last processed ledger and pages forward on each invocation.
+ */
+export async function getEvents(options: GetEventsOptions): Promise<ContractEvent[]> {
+  const { rpcUrl, contractId, startLedger, limit = 100, filter } = options;
+  const server = new SorobanRpc.Server(rpcUrl);
+
+  const topicsFilter = buildTopicsFilter(filter);
+
+  const response = await server.getEvents({
+    startLedger: startLedger ?? undefined,
+    filters: [{ type: 'contract', contractIds: [contractId], topics: topicsFilter }],
+    limit,
+  });
+
+  if (!response.events?.length) return [];
+
+  return response.events
+    .map(parseRawEvent)
+    .filter((e): e is ContractEvent => e !== null);
+}
+
+function buildTopicsFilter(filter?: EventFilter): string[][] | undefined {
+  const topic = filter?.topic;
+  if (!topic) return undefined;
+  return Array.isArray(topic[0]) ? (topic as string[][]) : [topic as string[]];
+}
+
+function parseRawEvent(event: SorobanRpc.Api.EventResponse): ContractEvent | null {
+  try {
+    if (event.type !== 'contract') return null;
+
+    const contractId =
+      typeof event.contractId === 'string'
+        ? event.contractId
+        : (event.contractId as Contract).contractId();
+
+    const topic = Array.isArray(event.topic)
+      ? (event.topic as xdr.ScVal[]).map((t) => JSON.stringify(scValToNative(t)))
+      : [];
+
+    const value =
+      event.value instanceof xdr.ScVal
+        ? (scValToNative(event.value) as Record<string, unknown>)
+        : {};
+
+    return { type: event.type, contractId, topic, value, ledger: event.ledger, txHash: event.txHash };
+  } catch {
+    return null;
+  }
+}
+
 export class SorobanEventListener {
   private server: SorobanRpc.Server;
   private contractId: string;
@@ -82,47 +151,11 @@ export class SorobanEventListener {
     this.isRunning = false;
   }
 
-  /**
-   * Parse a raw Soroban event into a ContractEvent.
-   */
-  private parseEvent(
-    event: SorobanRpc.Api.EventResponse
-  ): ContractEvent | null {
-    try {
-      if (event.type !== 'contract') return null;
-
-      const contractId =
-        typeof event.contractId === 'string'
-          ? event.contractId
-          : (event.contractId as Contract).contractId();
-
-      const topic = Array.isArray(event.topic)
-        ? (event.topic as xdr.ScVal[]).map((t) =>
-            JSON.stringify(scValToNative(t))
-          )
-        : [];
-
-      const value =
-        event.value instanceof xdr.ScVal
-          ? (scValToNative(event.value) as Record<string, unknown>)
-          : {};
-
-      return {
-        type: event.type,
-        contractId,
-        topic,
-        value,
-        ledger: event.ledger,
-        txHash: event.txHash,
-      };
-    } catch {
-      return null;
-    }
+  private parseEvent(event: SorobanRpc.Api.EventResponse): ContractEvent | null {
+    return parseRawEvent(event);
   }
 
   private getTopicsFilter(): string[][] | undefined {
-    const topic = this.filter?.topic;
-    if (!topic) return undefined;
-    return Array.isArray(topic[0]) ? (topic as string[][]) : [topic as string[]];
+    return buildTopicsFilter(this.filter);
   }
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,7 +1,7 @@
 export { IdentityClient } from './identity';
 export { CredentialClient } from './credentials';
 export { ReputationClient } from './reputation';
-export { SorobanEventListener } from './events';
+export { SorobanEventListener, getEvents } from './events';
 export { SorobanTransactionBuilder } from './transaction-builder';
 export { RequestQueue } from './request-queue';
 export {
@@ -30,7 +30,7 @@ export type {
   ReputationStorageStats,
 } from './types';
 export type { ReputationRecord, ScoreHistoryEntry } from './reputation';
-export type { EventFilter, ContractEvent } from './events';
+export type { EventFilter, ContractEvent, GetEventsOptions } from './events';
 import type { SorobanIdentityConfig } from './types';
 export type { SorobanIdentityConfig };
 


### PR DESCRIPTION
## Summary

- **#212** — Added CSP and security response headers (`Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`) to `vite.config.ts` for both dev and preview servers; `connect-src` is restricted to whitelisted Soroban RPC origins and the WalletConnect relay
- **#206** — Fixed `config.ts` to delegate to `getNetworkConfig()` so all contract IDs and RPC URLs are resolved from `.env.example` env vars; fixed `App.tsx` effects to use the in-scope `networkConfig` so health/init checks reflect the user-selected network
- **#211** — Added secret key security checks to `deploy.sh`: explicit validation, shell-history leak warning, secrets-manager guidance (GitHub Actions, AWS, Vault, 1Password), and a 10-second abort window before any mainnet deployment
- **#213** — Added `getEvents()` one-shot utility to the SDK that wraps the Soroban RPC `getEvents` endpoint for historical queries, with embedded indexing strategy docs; extracted shared helpers used by `SorobanEventListener`; exported `GetEventsOptions` from the public SDK surface

## Test plan

- [ ] `vite dev` — check browser DevTools Network tab shows CSP header on responses
- [ ] Copy `.env.example` to `.env`, fill in contract IDs, confirm the app reads them without code changes
- [ ] Switch network selector between testnet/mainnet and confirm health check pings the correct RPC URL
- [ ] Run `scripts/deploy.sh` without `STELLAR_SECRET_KEY` set — confirm error message with secrets-manager guidance appears
- [ ] Run `scripts/deploy.sh --network mainnet` with key set — confirm 10-second abort window appears
- [ ] Import `getEvents` from the SDK and call it with a valid `rpcUrl` + `contractId` — confirm it returns `ContractEvent[]`

Closes #206, #211, #212, #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)