### PR TITLE
fix: wire frontend config to network-aware env vars

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,6 @@ import {
   type NetworkName,
 } from "./network";
 import { checkConnection, IdentityClient, CredentialClient, ReputationClient } from "../../sdk/src/index";
-import { getAppConfig } from "./config";
 import type { Credential } from "../../sdk/src/types";
 
 type Tab = "identity" | "credentials";
@@ -63,8 +62,10 @@ export default function App() {
   // Check RPC connection health on load
   useEffect(() => {
     const checkRpcHealth = async () => {
-      const config = getAppConfig();
-      const server = new SorobanRpc.Server(config.rpcUrl);
+      const rpcUrl = Array.isArray(networkConfig.rpcUrl)
+        ? networkConfig.rpcUrl[0]
+        : networkConfig.rpcUrl;
+      const server = new SorobanRpc.Server(rpcUrl);
       const healthy = await checkConnection(server);
       setIsConnected(healthy);
     };
@@ -74,10 +75,9 @@ export default function App() {
   // Check contract initialization on load
   useEffect(() => {
     const checkInit = async () => {
-      const config = getAppConfig();
-      const identity = new IdentityClient(config);
-      const credentials = new CredentialClient(config);
-      const reputation = new ReputationClient(config);
+      const identity = new IdentityClient(networkConfig);
+      const credentials = new CredentialClient(networkConfig);
+      const reputation = new ReputationClient(networkConfig);
       const [idOk, credOk, repOk] = await Promise.all([
         identity.isInitialized(),
         credentials.isInitialized(),

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,12 +1,7 @@
+import { getNetworkConfig } from './network';
+
+// Returns config for the active network, resolved from VITE_NETWORK / VITE_*_RPC_URL
+// / VITE_*_IDENTITY_REGISTRY_ID env vars defined in .env.example.
 export function getAppConfig() {
-  // Support multiple RPC URLs separated by commas
-  const rpcUrls = import.meta.env.VITE_RPC_URL?.split(',').map((url: string) => url.trim()).filter(Boolean);
-  
-  return {
-    rpcUrl: rpcUrls && rpcUrls.length > 1 ? rpcUrls : import.meta.env.VITE_RPC_URL,
-    networkPassphrase: import.meta.env.VITE_NETWORK_PASSPHRASE,
-    identityRegistryId: import.meta.env.VITE_IDENTITY_REGISTRY_ID,
-    credentialManagerId: import.meta.env.VITE_CREDENTIAL_MANAGER_ID,
-    reputationId: import.meta.env.VITE_REPUTATION_ID,
-  };
+  return getNetworkConfig();
 }


### PR DESCRIPTION
## Summary

`config.ts` was reading `VITE_RPC_URL`, `VITE_NETWORK_PASSPHRASE`, `VITE_IDENTITY_REGISTRY_ID` etc. — none of which exist in `.env.example`. This made it impossible to deploy to different environments without editing source files.

- Updated `getAppConfig()` to delegate to `getNetworkConfig()`, which resolves all values from the `VITE_NETWORK` / `VITE_*_RPC_URL` / `VITE_*_IDENTITY_REGISTRY_ID` env vars already documented in `.env.example`
- Fixed two `useEffect` hooks in `App.tsx` that called `getAppConfig()` (which ignored the user-selected network) to use the already-in-scope `networkConfig` instead, so RPC health checks and contract init checks always reflect the active network

## Test plan

- [ ] Copy `.env.example` → `.env`, fill in contract IDs, run `npm run dev` — confirm app starts and reads IDs without any code change
- [ ] Switch the network selector between testnet/mainnet — confirm the RPC health indicator re-checks against the correct endpoint

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)