### PR TITLE
feat: add getEvents() one-shot utility and event indexing docs to SDK

### DIFF
--- a/sdk/src/events.ts
+++ b/sdk/src/events.ts
@@ -14,6 +14,75 @@ export interface ContractEvent {
   txHash: string;
 }
 
+export interface GetEventsOptions {
+  rpcUrl: string;
+  contractId: string;
+  /** Ledger to start scanning from. Omit to start from the oldest available. */
+  startLedger?: number;
+  /** Maximum number of events to return. Defaults to 100. */
+  limit?: number;
+  filter?: EventFilter;
+}
+
+/**
+ * One-shot fetch of historical contract events via the Soroban RPC getEvents
+ * endpoint. For real-time updates use SorobanEventListener instead.
+ *
+ * Event indexing strategy:
+ *   - For lightweight queries: call this utility with a known startLedger.
+ *   - For production indexing: consider the Mercury indexer for Soroban
+ *     (https://mercurydata.app) or run a custom listener that checkpoints
+ *     the last processed ledger and pages forward on each invocation.
+ */
+export async function getEvents(options: GetEventsOptions): Promise<ContractEvent[]> {
+  const { rpcUrl, contractId, startLedger, limit = 100, filter } = options;
+  const server = new SorobanRpc.Server(rpcUrl);
+
+  const topicsFilter = buildTopicsFilter(filter);
+
+  const response = await server.getEvents({
+    startLedger: startLedger ?? undefined,
+    filters: [{ type: 'contract', contractIds: [contractId], topics: topicsFilter }],
+    limit,
+  });
+
+  if (!response.events?.length) return [];
+
+  return response.events
+    .map(parseRawEvent)
+    .filter((e): e is ContractEvent => e !== null);
+}
+
+function buildTopicsFilter(filter?: EventFilter): string[][] | undefined {
+  const topic = filter?.topic;
+  if (!topic) return undefined;
+  return Array.isArray(topic[0]) ? (topic as string[][]) : [topic as string[]];
+}
+
+function parseRawEvent(event: SorobanRpc.Api.EventResponse): ContractEvent | null {
+  try {
+    if (event.type !== 'contract') return null;
+
+    const contractId =
+      typeof event.contractId === 'string'
+        ? event.contractId
+        : (event.contractId as Contract).contractId();
+
+    const topic = Array.isArray(event.topic)
+      ? (event.topic as xdr.ScVal[]).map((t) => JSON.stringify(scValToNative(t)))
+      : [];
+
+    const value =
+      event.value instanceof xdr.ScVal
+        ? (scValToNative(event.value) as Record<string, unknown>)
+        : {};
+
+    return { type: event.type, contractId, topic, value, ledger: event.ledger, txHash: event.txHash };
+  } catch {
+    return null;
+  }
+}
+
 export class SorobanEventListener {
   private server: SorobanRpc.Server;
   private contractId: string;
@@ -82,47 +151,11 @@ export class SorobanEventListener {
     this.isRunning = false;
   }
 
-  /**
-   * Parse a raw Soroban event into a ContractEvent.
-   */
-  private parseEvent(
-    event: SorobanRpc.Api.EventResponse
-  ): ContractEvent | null {
-    try {
-      if (event.type !== 'contract') return null;
-
-      const contractId =
-        typeof event.contractId === 'string'
-          ? event.contractId
-          : (event.contractId as Contract).contractId();
-
-      const topic = Array.isArray(event.topic)
-        ? (event.topic as xdr.ScVal[]).map((t) =>
-            JSON.stringify(scValToNative(t))
-          )
-        : [];
-
-      const value =
-        event.value instanceof xdr.ScVal
-          ? (scValToNative(event.value) as Record<string, unknown>)
-          : {};
-
-      return {
-        type: event.type,
-        contractId,
-        topic,
-        value,
-        ledger: event.ledger,
-        txHash: event.txHash,
-      };
-    } catch {
-      return null;
-    }
+  private parseEvent(event: SorobanRpc.Api.EventResponse): ContractEvent | null {
+    return parseRawEvent(event);
   }
 
   private getTopicsFilter(): string[][] | undefined {
-    const topic = this.filter?.topic;
-    if (!topic) return undefined;
-    return Array.isArray(topic[0]) ? (topic as string[][]) : [topic as string[]];
+    return buildTopicsFilter(this.filter);
   }
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,7 +1,7 @@
 export { IdentityClient } from './identity';
 export { CredentialClient } from './credentials';
 export { ReputationClient } from './reputation';
-export { SorobanEventListener } from './events';
+export { SorobanEventListener, getEvents } from './events';
 export { SorobanTransactionBuilder } from './transaction-builder';
 export { RequestQueue } from './request-queue';
 export {
@@ -30,7 +30,7 @@ export type {
   ReputationStorageStats,
 } from './types';
 export type { ReputationRecord, ScoreHistoryEntry } from './reputation';
-export type { EventFilter, ContractEvent } from './events';
+export type { EventFilter, ContractEvent, GetEventsOptions } from './events';
 import type { SorobanIdentityConfig } from './types';
 export type { SorobanIdentityConfig };
 


### PR DESCRIPTION
## Summary

The contracts emit events (DID created, credential issued, score submitted) but the SDK had no way to query them historically — only the polling-based `SorobanEventListener`. The frontend had no efficient path to historical data without rolling its own RPC call.

- Added `getEvents(options: GetEventsOptions): Promise<ContractEvent[]>` — a one-shot utility that wraps the Soroban RPC `getEvents` endpoint for historical/ad-hoc queries
- Extracted `parseRawEvent` and `buildTopicsFilter` as module-level helpers shared by both `getEvents` and `SorobanEventListener` (no behaviour change to the listener)
- Documented the recommended production indexing strategy in the JSDoc: use `startLedger` checkpointing for lightweight queries; use the Mercury indexer or a custom checkpoint-based listener for production-scale indexing
- Exported `getEvents` and `GetEventsOptions` from the SDK public surface (`sdk/src/index.ts`)

## Test plan

- [ ] Import `getEvents` from the SDK and call it with a valid `rpcUrl` + `contractId` — confirm it returns `ContractEvent[]`
- [ ] Pass a `startLedger` and `filter` — confirm only matching events are returned
- [ ] Confirm `SorobanEventListener` still starts, polls, and stops correctly (existing tests pass)

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)