### PR TITLE
Implement server operations endpoints for health and metrics

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -1,6 +1,7 @@
 name: Contracts CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -113,3 +114,17 @@ jobs:
       - name: Test reputation
         working-directory: contracts/reputation
         run: cargo test
+
+  post-deployment-health-check:
+    name: Post-deployment Health Check
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify deployed contracts through server health endpoint
+        env:
+          SERVER_HEALTH_URL: ${{ secrets.SERVER_HEALTH_URL }}
+        run: scripts/post_deploy_health_check.sh

--- a/README.md
+++ b/README.md
@@ -57,11 +57,18 @@ soroban-identity/
 │   └── reputation/            # On-chain scoring and anti-sybil checks
 ├── frontend/                  # React + TypeScript dApp (Vite)
 ├── sdk/                       # TypeScript SDK for dApp integration
+├── server/                    # Operational API, expiry jobs, health, and metrics
 ├── scripts/
 │   └── deploy.sh              # Build + deploy all contracts to testnet
 └── docs/
     └── architecture.md        # Protocol architecture deep-dive
 ```
+
+---
+
+## Server Operations
+
+The `server/` package provides contract health checks, protected admin issuer management, credential expiry reporting and notifications, and Prometheus metrics. See [`docs/server-operations.md`](docs/server-operations.md) for configuration and scrape examples.
 
 ---
 

--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -1,9 +1,13 @@
 #![no_std]
 
+use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env,
     Map, String, Symbol, Vec,
 };
+
+/// Version returned by `ping` for deployment health checks.
+pub const CONTRACT_VERSION: u32 = 1;
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
@@ -90,6 +94,11 @@ pub struct CredentialManager;
 
 #[contractimpl]
 impl CredentialManager {
+    /// Lightweight read-only liveness check used by deployment monitors.
+    pub fn ping(_env: Env) -> u32 {
+        CONTRACT_VERSION
+    }
+
     // ── Admin ─────────────────────────────────────────────────────────────────
 
     /// Initializes the credential manager with an admin address.
@@ -121,7 +130,11 @@ impl CredentialManager {
     ///
     /// # Errors
     /// Returns [`ContractError::Unauthorized`] if `current_admin` does not match the stored admin address.
-    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), ContractError> {
+    pub fn transfer_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), ContractError> {
         current_admin.require_auth();
         let stored: Address = env
             .storage()
@@ -148,7 +161,11 @@ impl CredentialManager {
     ///
     /// # Errors
     /// Returns [`ContractError::Unauthorized`] if `admin` does not match the stored admin address.
-    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: Bytes) -> Result<(), ContractError> {
+    pub fn upgrade(
+        env: Env,
+        admin: Address,
+        new_wasm_hash: BytesN<32>,
+    ) -> Result<(), ContractError> {
         admin.require_auth();
         let stored: Address = env
             .storage()
@@ -174,7 +191,7 @@ impl CredentialManager {
     /// # Panics
     /// Panics with `"MaxIssuersReached"` if the issuer cap has been reached.
     pub fn add_issuer(env: Env, issuer: Address) -> Result<(), ContractError> {
-        Self::require_admin(&env);
+        Self::require_admin(&env)?;
         let mut issuers = Self::get_issuers_internal(&env);
         if !issuers.contains(&issuer) {
             if issuers.len() >= MAX_ISSUERS {
@@ -304,7 +321,7 @@ impl CredentialManager {
 
         env.events().publish(
             (CRED, symbol_short!("issued")),
-            (id.clone(), subject, issuer, credential_type),
+            (id.clone(), subject, issuer, credential_type, expires_at),
         );
 
         Ok(id)
@@ -535,20 +552,8 @@ impl CredentialManager {
             CredentialType::Custom => 3,
         };
         let mut data = Bytes::new(env);
-        data.extend_from_array(
-            &issuer
-                .clone()
-                .to_xdr(env)
-                .to_array::<64>()
-                .unwrap_or([0u8; 64]),
-        );
-        data.extend_from_array(
-            &subject
-                .clone()
-                .to_xdr(env)
-                .to_array::<64>()
-                .unwrap_or([0u8; 64]),
-        );
+        data.append(&issuer.clone().to_xdr(env));
+        data.append(&subject.clone().to_xdr(env));
         data.push_back(type_tag);
         env.crypto().sha256(&data).into()
     }

--- a/contracts/identity-registry/src/lib.rs
+++ b/contracts/identity-registry/src/lib.rs
@@ -20,6 +20,9 @@ pub enum ContractError {
     NotInitialized = 8,
 }
 
+/// Version returned by `ping` for deployment health checks.
+pub const CONTRACT_VERSION: u32 = 1;
+
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
 const IDENTITY: Symbol = symbol_short!("IDENTITY");
@@ -43,7 +46,7 @@ pub struct IdentityStorageStats {
 
 /// W3C-aligned DID document stored on-chain.
 #[contracttype]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DidDocument {
     /// did:stellar:<address>
     pub id: String,
@@ -66,6 +69,11 @@ pub struct IdentityRegistry;
 
 #[contractimpl]
 impl IdentityRegistry {
+    /// Lightweight read-only liveness check used by deployment monitors.
+    pub fn ping(_env: Env) -> u32 {
+        CONTRACT_VERSION
+    }
+
     // ── Admin ─────────────────────────────────────────────────────────────────
 
     /// Initializes the identity registry with an admin address.
@@ -97,7 +105,11 @@ impl IdentityRegistry {
     ///
     /// # Errors
     /// Returns [`ContractError::Unauthorized`] if `current_admin` does not match the stored admin address.
-    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), ContractError> {
+    pub fn transfer_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), ContractError> {
         current_admin.require_auth();
         let stored: Address = env
             .storage()
@@ -112,6 +124,7 @@ impl IdentityRegistry {
             (ADMIN, symbol_short!("transfer")),
             (current_admin, new_admin),
         );
+        Ok(())
     }
 
     /// Upgrades the contract WASM to a new hash. Only the admin can call this.
@@ -123,7 +136,11 @@ impl IdentityRegistry {
     ///
     /// # Errors
     /// Returns [`ContractError::Unauthorized`] if `admin` does not match the stored admin address.
-    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), ContractError> {
+    pub fn upgrade(
+        env: Env,
+        admin: Address,
+        new_wasm_hash: BytesN<32>,
+    ) -> Result<(), ContractError> {
         admin.require_auth();
         let stored: Address = env
             .storage()
@@ -246,10 +263,9 @@ impl IdentityRegistry {
         storage.extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
 
         // Hash the DID id + updated_at as a deterministic metadata fingerprint
-        let mut hash_input = Bytes::new(&env);
-        hash_input.extend_from_slice(&doc.id.clone().as_bytes());
+        let mut hash_input = Self::string_to_bytes(&env, &doc.id);
         hash_input.extend_from_array(&doc.updated_at.to_be_bytes());
-        let meta_hash = env.crypto().sha256(&hash_input);
+        let meta_hash = env.crypto().sha256(&hash_input).to_bytes();
         env.events().publish(
             (IDENTITY, symbol_short!("updated")),
             (controller, meta_hash),
@@ -371,47 +387,47 @@ impl IdentityRegistry {
         Ok(())
     }
 
-    fn did_key(env: &Env, controller: &Address) -> Bytes {
-        // Use the raw address bytes as the storage key
-        let mut key = Bytes::new(env);
-        key.extend_from_array(&[b'd', b'i', b'd', b':']);
-        // append address bytes — Address implements IntoVal<Env, Bytes> indirectly
-        // so we serialize via the env
-        let addr_bytes = controller.to_string().as_bytes();
-        key.extend_from_slice(&addr_bytes);
-        key
+    fn did_key(_env: &Env, controller: &Address) -> (Symbol, Address) {
+        (IDENTITY, controller.clone())
     }
 
     fn build_did_id(env: &Env, controller: &Address) -> Result<String, ContractError> {
-        // did:stellar:<bech32-address>
-        let prefix = String::from_str(env, "did:stellar:");
         let addr_str = controller.to_string();
-        let mut result = prefix.as_bytes();
-        result.extend_from_slice(&addr_str.as_bytes());
+        let mut addr_bytes = [0u8; 56];
+        addr_str.copy_into_slice(&mut addr_bytes);
+
+        let mut result = [0u8; 68];
+        result[..12].copy_from_slice(b"did:stellar:");
+        result[12..].copy_from_slice(&addr_bytes);
         let did = String::from_bytes(env, &result);
 
-        // Validate the format
         if !Self::validate_did_format(env, &did) {
-            return Err(ContractError::DidNotFound); // Use existing error for invalid format
+            return Err(ContractError::DidNotFound);
         }
 
         Ok(did)
     }
 
     fn validate_did_format(env: &Env, did: &String) -> bool {
-        let did_bytes = did.as_bytes();
-        let prefix = b"did:stellar:";
-        if did_bytes.len() < prefix.len() {
+        if did.len() != 68 {
             return false;
         }
-        // Check if it starts with "did:stellar:"
-        for i in 0..prefix.len() {
-            if did_bytes.get(i).unwrap() != prefix[i] {
+        let did_bytes = Self::string_to_bytes(env, did);
+        let prefix = b"did:stellar:";
+        for (i, expected) in prefix.iter().enumerate() {
+            if did_bytes.get(i as u32).unwrap() != *expected {
                 return false;
             }
         }
-        // Check that there's something after the prefix
-        did_bytes.len() > prefix.len()
+        true
+    }
+
+    fn string_to_bytes(env: &Env, value: &String) -> Bytes {
+        let mut result = Bytes::new(env);
+        let mut buffer = [0u8; 68];
+        value.copy_into_slice(&mut buffer[..value.len() as usize]);
+        result.extend_from_slice(&buffer[..value.len() as usize]);
+        result
     }
 }
 
@@ -421,6 +437,8 @@ impl IdentityRegistry {
 mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Env, Map};
+    extern crate std;
+    use std::string::ToString;
 
     #[test]
     fn test_double_initialize_returns_error() {
@@ -485,6 +503,9 @@ mod tests {
 
         // The address part should match the controller
         let expected_addr = user.to_string();
+        let mut expected_addr_bytes = [0u8; 56];
+        expected_addr.copy_into_slice(&mut expected_addr_bytes);
+        let expected_addr = std::str::from_utf8(&expected_addr_bytes).unwrap();
         let addr_part = &did_str["did:stellar:".len()..];
         assert_eq!(addr_part, expected_addr);
     }

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -11,6 +11,9 @@ use soroban_sdk::{
     Symbol, Vec,
 };
 
+/// Version returned by `ping` for deployment health checks.
+pub const CONTRACT_VERSION: u32 = 1;
+
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
 const ADMIN: Symbol = symbol_short!("ADMIN");
@@ -83,6 +86,11 @@ pub struct Reputation;
 
 #[contractimpl]
 impl Reputation {
+    /// Lightweight read-only liveness check used by deployment monitors.
+    pub fn ping(_env: Env) -> u32 {
+        CONTRACT_VERSION
+    }
+
     // ── Admin ─────────────────────────────────────────────────────────────────
 
     /// Initializes the reputation contract with an admin address.
@@ -114,7 +122,11 @@ impl Reputation {
     ///
     /// # Errors
     /// Returns [`ContractError::Unauthorized`] if `current_admin` does not match the stored admin address.
-    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) -> Result<(), ContractError> {
+    pub fn transfer_admin(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), ContractError> {
         current_admin.require_auth();
         let stored: Address = env
             .storage()
@@ -133,7 +145,11 @@ impl Reputation {
     }
 
     /// Upgrade the contract WASM. Only the admin can call this.
-    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), ContractError> {
+    pub fn upgrade(
+        env: Env,
+        admin: Address,
+        new_wasm_hash: BytesN<32>,
+    ) -> Result<(), ContractError> {
         admin.require_auth();
         let stored: Address = env
             .storage()
@@ -166,6 +182,7 @@ impl Reputation {
                 (reporter, env.ledger().timestamp()),
             );
         }
+        Ok(())
     }
 
     /// Removes a trusted reporter (admin only).
@@ -203,7 +220,11 @@ impl Reputation {
     /// * `env` - The Soroban environment.
     /// * `min_score` - Minimum accumulated score a subject must have.
     /// * `min_reporters` - Minimum number of distinct active reporters required.
-    pub fn set_default_threshold(env: Env, min_score: i64, min_reporters: u32) -> Result<(), ContractError> {
+    pub fn set_default_threshold(
+        env: Env,
+        min_score: i64,
+        min_reporters: u32,
+    ) -> Result<(), ContractError> {
         Self::require_admin(&env)?;
         env.storage().instance().set(
             &DEF_THRESH,
@@ -243,9 +264,10 @@ impl Reputation {
             .persistent()
             .get::<(Symbol, Address), ReputationRecord>(&key)
         {
-            None => false,
+            None => Ok(false),
             Some(rec) => {
-                Ok(rec.score >= threshold.min_score && rec.reporter_count >= threshold.min_reporters)
+                Ok(rec.score >= threshold.min_score
+                    && rec.reporter_count >= threshold.min_reporters)
             }
         }
     }

--- a/contracts/tests/lifecycle.rs
+++ b/contracts/tests/lifecycle.rs
@@ -104,3 +104,12 @@ fn reputation_lifecycle_and_sybil_gate() {
     assert_eq!(record.score, 0);
     assert!(!reputation.passes_sybil_check(&subject, &50, &1));
 }
+#[test]
+fn contracts_expose_ping_version() {
+    let env = Env::default();
+    let (identity, credentials, reputation) = register_clients(&env);
+
+    assert_eq!(identity.ping(), 1);
+    assert_eq!(credentials.ping(), 1);
+    assert_eq!(reputation.ping(), 1);
+}

--- a/docs/server-operations.md
+++ b/docs/server-operations.md
@@ -1,0 +1,47 @@
+# Server Operations
+
+The `server/` package exposes operational endpoints for deployed Soroban Identity contracts.
+
+## Configuration
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `PORT` | HTTP listen port. | `3001` |
+| `ADMIN_API_KEY` | Required `x-api-key` or Bearer token for `/admin/*` routes. | unset |
+| `ADMIN_ACTOR` | Default actor written to the issuer audit log. | `admin` |
+| `STELLAR_SOURCE_ACCOUNT` / `STELLAR_SECRET_KEY` | Source account used by Stellar CLI contract invocations. | unset |
+| `STELLAR_NETWORK` | Stellar network passphrase alias used by the CLI. | `testnet` |
+| `STELLAR_RPC_URL` | Soroban RPC URL. | testnet RPC |
+| `IDENTITY_REGISTRY_ID` | Identity registry contract ID. | unset |
+| `CREDENTIAL_MANAGER_ID` | Credential manager contract ID. | unset |
+| `REPUTATION_ID` | Reputation contract ID. | unset |
+| `EXPIRY_WARNING_DAYS` | Credential expiry warning window. | `7` |
+| `EXPIRY_JOB_INTERVAL_MS` | Background expiry job interval. | `3600000` |
+| `NOTIFICATION_WEBHOOK_URL` | Default webhook receiving credential expiry warnings. | unset |
+| `SUBJECT_NOTIFICATION_WEBHOOKS` | JSON map of subject address to webhook URL. | `{}` |
+
+## Endpoints
+
+- `GET /health` calls `ping()` on the identity, credential, and reputation contracts in parallel and returns HTTP `503` if any contract cannot respond.
+- `GET /metrics` returns Prometheus-compatible counters for DID, credential, and reputation activity plus an RPC latency histogram.
+- `GET /admin/issuers` returns the registered issuer list from the credential contract.
+- `POST /admin/issuers` with `{ "issuer": "G..." }` calls `add_issuer` and appends an audit log entry.
+- `DELETE /admin/issuers?issuer=G...` or `DELETE /admin/issuers` with `{ "issuer": "G..." }` calls `remove_issuer` and appends an audit log entry.
+- `GET /admin/expiry-report?windowDays=7&page=1&pageSize=50` returns a paginated list of credentials expiring inside the requested window.
+
+All `/admin/*` routes require `x-api-key: $ADMIN_API_KEY` or `Authorization: Bearer $ADMIN_API_KEY`.
+
+## Expiry notifications
+
+The server starts a background job every hour by default. It indexes credential issue events when available, reads the local credential store, finds credentials with `expires_at` inside the configured warning window, and dispatches a webhook POST to the configured subject-specific or default notification URL.
+
+## Prometheus scrape config
+
+```yaml
+scrape_configs:
+  - job_name: soroban_identity_server
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - soroban-identity.example.com:3001
+```

--- a/scripts/post_deploy_health_check.sh
+++ b/scripts/post_deploy_health_check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_HEALTH_URL="${SERVER_HEALTH_URL:-http://localhost:3001/health}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-12}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  echo "Checking deployment health ($attempt/$MAX_ATTEMPTS): $SERVER_HEALTH_URL"
+  if curl --fail --silent --show-error "$SERVER_HEALTH_URL"; then
+    echo ""
+    echo "Deployment health check passed."
+    exit 0
+  fi
+  sleep "$SLEEP_SECONDS"
+done
+
+echo "Deployment health check failed after $MAX_ATTEMPTS attempts." >&2
+exit 1

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@soroban-identity/server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Operational HTTP service for Soroban Identity contracts",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,0 +1,62 @@
+import { URL } from 'node:url';
+import { appendAuditLog, readCredentials } from './storage.js';
+import { findExpiringCredentials, paginate } from './expiry.js';
+import { notFound, readJson, requireAdmin, sendJson, sendText } from './http-utils.js';
+
+export function createApp({ config, soroban, metrics, metricsAggregator }) {
+  return async function app(req, res) {
+    try {
+      const url = new URL(req.url, `http://${req.headers.host ?? 'localhost'}`);
+
+      if (req.method === 'GET' && url.pathname === '/health') {
+        const contracts = await soroban.pingAllContracts();
+        const ok = Object.values(contracts).every(Boolean);
+        return sendJson(res, ok ? 200 : 503, { status: ok ? 'ok' : 'degraded', contracts });
+      }
+
+      if (req.method === 'GET' && url.pathname === '/metrics') {
+        if (metricsAggregator) await metricsAggregator.refresh().catch((error) => console.error('metrics refresh failed', error));
+        return sendText(res, 200, metrics.renderPrometheus());
+      }
+
+      if (url.pathname.startsWith('/admin/') && !requireAdmin(req, res, config)) return;
+
+      if (req.method === 'GET' && url.pathname === '/admin/issuers') {
+        const issuers = await soroban.getIssuers();
+        return sendJson(res, 200, { issuers });
+      }
+
+      if (req.method === 'POST' && url.pathname === '/admin/issuers') {
+        const body = await readJson(req);
+        if (!body.issuer) return sendJson(res, 400, { error: 'issuer_required' });
+        await soroban.addIssuer(body.issuer);
+        await appendAuditLog(config, { action: 'add_issuer', actor: req.headers['x-actor'] ?? config.adminActor, issuer: body.issuer });
+        return sendJson(res, 201, { issuer: body.issuer });
+      }
+
+      if (req.method === 'DELETE' && url.pathname === '/admin/issuers') {
+        const body = await readJson(req);
+        const issuer = body.issuer ?? url.searchParams.get('issuer');
+        if (!issuer) return sendJson(res, 400, { error: 'issuer_required' });
+        await soroban.removeIssuer(issuer);
+        await appendAuditLog(config, { action: 'remove_issuer', actor: req.headers['x-actor'] ?? config.adminActor, issuer });
+        return sendJson(res, 200, { issuer });
+      }
+
+      if (req.method === 'GET' && url.pathname === '/admin/expiry-report') {
+        const windowDays = Number.parseInt(url.searchParams.get('windowDays') ?? '', 10) || config.expiryWarningDays;
+        const credentials = await readCredentials(config);
+        const expiring = findExpiringCredentials(credentials, { windowDays, includeNotified: true });
+        return sendJson(res, 200, paginate(expiring, {
+          page: url.searchParams.get('page'),
+          pageSize: url.searchParams.get('pageSize'),
+        }));
+      }
+
+      return notFound(res);
+    } catch (error) {
+      console.error(error);
+      return sendJson(res, 500, { error: 'internal_server_error', message: error.message });
+    }
+  };
+}

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,0 +1,41 @@
+import path from 'node:path';
+
+const DEFAULT_DATA_DIR = path.resolve(process.cwd(), 'data');
+
+function parseInteger(value, fallback) {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseJson(value, fallback) {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new Error(`Invalid JSON configuration: ${error.message}`);
+  }
+}
+
+export function loadConfig(env = process.env) {
+  return {
+    port: parseInteger(env.PORT, 3001),
+    adminApiKey: env.ADMIN_API_KEY ?? '',
+    adminActor: env.ADMIN_ACTOR ?? 'admin',
+    dataDir: env.DATA_DIR ? path.resolve(env.DATA_DIR) : DEFAULT_DATA_DIR,
+    auditLogPath: env.AUDIT_LOG_PATH ? path.resolve(env.AUDIT_LOG_PATH) : path.join(DEFAULT_DATA_DIR, 'issuer-audit.jsonl'),
+    credentialStorePath: env.CREDENTIAL_STORE_PATH ? path.resolve(env.CREDENTIAL_STORE_PATH) : path.join(DEFAULT_DATA_DIR, 'credentials.json'),
+    expiryWarningDays: parseInteger(env.EXPIRY_WARNING_DAYS, 7),
+    expiryJobIntervalMs: parseInteger(env.EXPIRY_JOB_INTERVAL_MS, 60 * 60 * 1000),
+    notificationWebhookUrl: env.NOTIFICATION_WEBHOOK_URL ?? '',
+    subjectNotificationWebhooks: parseJson(env.SUBJECT_NOTIFICATION_WEBHOOKS, {}),
+    stellarCli: env.STELLAR_CLI ?? 'stellar',
+    sourceAccount: env.STELLAR_SOURCE_ACCOUNT ?? env.STELLAR_SECRET_KEY ?? '',
+    network: env.STELLAR_NETWORK ?? 'testnet',
+    rpcUrl: env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org',
+    contracts: {
+      identity: env.IDENTITY_REGISTRY_ID ?? '',
+      credential: env.CREDENTIAL_MANAGER_ID ?? '',
+      reputation: env.REPUTATION_ID ?? '',
+    },
+  };
+}

--- a/server/src/expiry.js
+++ b/server/src/expiry.js
@@ -1,0 +1,104 @@
+import { readCredentials, upsertCredential, writeCredentials } from './storage.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function findExpiringCredentials(credentials, { windowDays, now = new Date(), includeNotified = false } = {}) {
+  const nowMs = now.getTime();
+  const upper = nowMs + windowDays * DAY_MS;
+  return credentials
+    .filter((credential) => Number(credential.expires_at) > 0)
+    .filter((credential) => Number(credential.expires_at) * 1000 >= nowMs && Number(credential.expires_at) * 1000 <= upper)
+    .filter((credential) => includeNotified || !credential.expiry_notified_at)
+    .sort((a, b) => Number(a.expires_at) - Number(b.expires_at));
+}
+
+export function paginate(items, { page = 1, pageSize = 50 } = {}) {
+  const safePage = Math.max(1, Number.parseInt(page, 10) || 1);
+  const safePageSize = Math.min(200, Math.max(1, Number.parseInt(pageSize, 10) || 50));
+  const start = (safePage - 1) * safePageSize;
+  return {
+    page: safePage,
+    pageSize: safePageSize,
+    total: items.length,
+    items: items.slice(start, start + safePageSize),
+  };
+}
+
+export class ExpiryNotificationJob {
+  constructor(config, soroban = null) {
+    this.config = config;
+    this.soroban = soroban;
+    this.timer = null;
+    this.nextLedger = Number.parseInt(process.env.EXPIRY_EVENTS_START_LEDGER ?? '0', 10);
+  }
+
+  start() {
+    if (this.timer) return;
+    this.runOnce().catch((error) => console.error('expiry job failed', error));
+    this.timer = setInterval(() => {
+      this.runOnce().catch((error) => console.error('expiry job failed', error));
+    }, this.config.expiryJobIntervalMs);
+  }
+
+  stop() {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async runOnce() {
+    let credentials = await readCredentials(this.config);
+    credentials = await this.indexCredentialEvents(credentials);
+    const expiring = findExpiringCredentials(credentials, { windowDays: this.config.expiryWarningDays });
+    for (const credential of expiring) {
+      await this.dispatch(credential);
+      credentials = upsertCredential(credentials, { ...credential, expiry_notified_at: new Date().toISOString() });
+    }
+    await writeCredentials(this.config, credentials);
+    return expiring.length;
+  }
+
+  async indexCredentialEvents(credentials) {
+    if (!this.soroban) return credentials;
+    const events = await this.soroban.getEvents(this.nextLedger);
+    let next = credentials;
+    for (const event of events) {
+      const credential = credentialFromEvent(event);
+      if (credential) next = upsertCredential(next, credential);
+    }
+    const newest = events.map((event) => Number(event.ledger ?? 0)).filter(Number.isFinite).sort((a, b) => b - a)[0];
+    if (newest) this.nextLedger = newest + 1;
+    return next;
+  }
+
+  async dispatch(credential) {
+    const target = this.config.subjectNotificationWebhooks[credential.subject] ?? this.config.notificationWebhookUrl;
+    if (!target) return;
+    const response = await fetch(target, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        type: 'credential.expiring',
+        credential_id: credential.id,
+        subject: credential.subject,
+        issuer: credential.issuer,
+        expires_at: credential.expires_at,
+        warning_window_days: this.config.expiryWarningDays,
+      }),
+    });
+    if (!response.ok) throw new Error(`notification dispatch failed with HTTP ${response.status}`);
+  }
+}
+
+export function credentialFromEvent(event) {
+  const text = JSON.stringify(event).toLowerCase();
+  if (!text.includes('cred') || !text.includes('issued')) return null;
+  const value = event.value ?? event.data ?? event;
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const id = value.id ?? value.credential_id;
+    const subject = value.subject;
+    const issuer = value.issuer;
+    const expires_at = Number(value.expires_at);
+    if (id && subject && issuer && expires_at) return { id, subject, issuer, expires_at, source: 'event' };
+  }
+  return null;
+}

--- a/server/src/http-utils.js
+++ b/server/src/http-utils.js
@@ -1,0 +1,35 @@
+export async function readJson(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  if (chunks.length === 0) return {};
+  const raw = Buffer.concat(chunks).toString('utf8');
+  if (!raw.trim()) return {};
+  return JSON.parse(raw);
+}
+
+export function sendJson(res, statusCode, body, headers = {}) {
+  res.writeHead(statusCode, { 'content-type': 'application/json; charset=utf-8', ...headers });
+  res.end(JSON.stringify(body));
+}
+
+export function sendText(res, statusCode, body, headers = {}) {
+  res.writeHead(statusCode, { 'content-type': 'text/plain; version=0.0.4; charset=utf-8', ...headers });
+  res.end(body);
+}
+
+export function notFound(res) {
+  sendJson(res, 404, { error: 'not_found' });
+}
+
+export function requireAdmin(req, res, config) {
+  if (!config.adminApiKey) {
+    sendJson(res, 503, { error: 'admin_api_key_not_configured' });
+    return false;
+  }
+  const token = req.headers['x-api-key'] || req.headers.authorization?.replace(/^Bearer\s+/i, '');
+  if (token !== config.adminApiKey) {
+    sendJson(res, 401, { error: 'unauthorized' });
+    return false;
+  }
+  return true;
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,26 @@
+import http from 'node:http';
+import { loadConfig } from './config.js';
+import { createApp } from './app.js';
+import { ensureDataDir } from './storage.js';
+import { ExpiryNotificationJob } from './expiry.js';
+import { MetricsAggregator, MetricsService } from './metrics.js';
+import { SorobanClient } from './soroban.js';
+
+const config = loadConfig();
+await ensureDataDir(config);
+const metrics = new MetricsService();
+const soroban = new SorobanClient(config, metrics);
+const metricsAggregator = new MetricsAggregator(soroban, metrics, { startLedger: Number.parseInt(process.env.METRICS_START_LEDGER ?? '0', 10) });
+const expiryJob = new ExpiryNotificationJob(config, soroban);
+
+if (process.env.DISABLE_EXPIRY_JOB !== 'true') expiryJob.start();
+
+const server = http.createServer(createApp({ config, soroban, metrics, metricsAggregator }));
+server.listen(config.port, () => {
+  console.log(`Soroban Identity server listening on :${config.port}`);
+});
+
+process.on('SIGTERM', () => {
+  expiryJob.stop();
+  server.close(() => process.exit(0));
+});

--- a/server/src/metrics.js
+++ b/server/src/metrics.js
@@ -1,0 +1,61 @@
+const HISTOGRAM_BUCKETS = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
+
+export class MetricsService {
+  constructor() {
+    this.counters = {
+      dids_created_total: 0,
+      credentials_issued_total: 0,
+      credentials_revoked_total: 0,
+      reputation_scores_submitted_total: 0,
+    };
+    this.rpcLatencies = [];
+  }
+
+  observeRpcLatency(seconds) {
+    this.rpcLatencies.push(seconds);
+    if (this.rpcLatencies.length > 10_000) this.rpcLatencies.shift();
+  }
+
+  applyEvents(events) {
+    for (const event of events) {
+      const text = JSON.stringify(event).toLowerCase();
+      if (text.includes('did') && (text.includes('create') || text.includes('created'))) this.counters.dids_created_total += 1;
+      if (text.includes('credential') && (text.includes('issue') || text.includes('issued'))) this.counters.credentials_issued_total += 1;
+      if (text.includes('credential') && (text.includes('revoke') || text.includes('revoked'))) this.counters.credentials_revoked_total += 1;
+      if (text.includes('score') && (text.includes('submit') || text.includes('submitted'))) this.counters.reputation_scores_submitted_total += 1;
+    }
+  }
+
+  renderPrometheus() {
+    const lines = [];
+    for (const [name, value] of Object.entries(this.counters)) {
+      lines.push(`# TYPE ${name} counter`, `${name} ${value}`);
+    }
+    lines.push('# TYPE soroban_rpc_call_latency_seconds histogram');
+    let cumulative = 0;
+    for (const bucket of HISTOGRAM_BUCKETS) {
+      cumulative = this.rpcLatencies.filter((value) => value <= bucket).length;
+      lines.push(`soroban_rpc_call_latency_seconds_bucket{le="${bucket}"} ${cumulative}`);
+    }
+    lines.push(`soroban_rpc_call_latency_seconds_bucket{le="+Inf"} ${this.rpcLatencies.length}`);
+    lines.push(`soroban_rpc_call_latency_seconds_sum ${this.rpcLatencies.reduce((sum, value) => sum + value, 0)}`);
+    lines.push(`soroban_rpc_call_latency_seconds_count ${this.rpcLatencies.length}`);
+    return `${lines.join('\n')}\n`;
+  }
+}
+
+export class MetricsAggregator {
+  constructor(soroban, metrics, { startLedger = 0 } = {}) {
+    this.soroban = soroban;
+    this.metrics = metrics;
+    this.nextLedger = startLedger;
+  }
+
+  async refresh() {
+    const events = await this.soroban.getEvents(this.nextLedger);
+    this.metrics.applyEvents(events);
+    const newest = events.map((event) => Number(event.ledger ?? event.ledgerClosedAt ?? 0)).filter(Number.isFinite).sort((a, b) => b - a)[0];
+    if (newest) this.nextLedger = newest + 1;
+    return events.length;
+  }
+}

--- a/server/src/soroban.js
+++ b/server/src/soroban.js
@@ -1,0 +1,106 @@
+import { spawn } from 'node:child_process';
+
+export class SorobanClient {
+  constructor(config, metrics) {
+    this.config = config;
+    this.metrics = metrics;
+  }
+
+  async invoke(contractId, method, args = []) {
+    if (!contractId) throw new Error('Contract ID is not configured');
+    if (!this.config.sourceAccount) throw new Error('STELLAR_SOURCE_ACCOUNT or STELLAR_SECRET_KEY is required');
+    const commandArgs = [
+      'contract',
+      'invoke',
+      '--id', contractId,
+      '--source', this.config.sourceAccount,
+      '--network', this.config.network,
+      '--rpc-url', this.config.rpcUrl,
+      '--',
+      method,
+      ...args,
+    ];
+    const started = performance.now();
+    try {
+      const output = await runCommand(this.config.stellarCli, commandArgs);
+      this.metrics?.observeRpcLatency((performance.now() - started) / 1000);
+      return output.trim();
+    } catch (error) {
+      this.metrics?.observeRpcLatency((performance.now() - started) / 1000);
+      throw error;
+    }
+  }
+
+  async pingAllContracts() {
+    const entries = Object.entries(this.config.contracts);
+    const results = await Promise.allSettled(entries.map(([name, id]) => this.invoke(id, 'ping').then(() => [name, true])));
+    const contracts = Object.fromEntries(entries.map(([name]) => [name, false]));
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        const [name, ok] = result.value;
+        contracts[name] = ok;
+      }
+    }
+    return contracts;
+  }
+
+  async getIssuers() {
+    const raw = await this.invoke(this.config.contracts.credential, 'get_issuers');
+    return parseAddressList(raw);
+  }
+
+  async addIssuer(issuer) {
+    return this.invoke(this.config.contracts.credential, 'add_issuer', ['--issuer', issuer]);
+  }
+
+  async removeIssuer(issuer) {
+    return this.invoke(this.config.contracts.credential, 'remove_issuer', ['--issuer', issuer]);
+  }
+
+  async getEvents(startLedger) {
+    const started = performance.now();
+    try {
+      const body = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'getEvents',
+        params: {
+          startLedger,
+          filters: [{ type: 'contract' }],
+          limit: 200,
+        },
+      };
+      const response = await fetch(this.config.rpcUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) throw new Error(`RPC getEvents failed with HTTP ${response.status}`);
+      const payload = await response.json();
+      if (payload.error) throw new Error(payload.error.message ?? 'RPC getEvents failed');
+      return payload.result?.events ?? [];
+    } finally {
+      this.metrics?.observeRpcLatency((performance.now() - started) / 1000);
+    }
+  }
+}
+
+function runCommand(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve(stdout);
+      else reject(new Error(stderr || stdout || `${command} exited with ${code}`));
+    });
+  });
+}
+
+function parseAddressList(raw) {
+  const matches = raw.match(/G[A-Z0-9]{55}/g);
+  return matches ? [...new Set(matches)] : [];
+}

--- a/server/src/storage.js
+++ b/server/src/storage.js
@@ -1,0 +1,39 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export async function ensureDataDir(config) {
+  await fs.mkdir(config.dataDir, { recursive: true });
+  await fs.mkdir(path.dirname(config.auditLogPath), { recursive: true });
+  await fs.mkdir(path.dirname(config.credentialStorePath), { recursive: true });
+}
+
+export async function appendAuditLog(config, entry) {
+  await ensureDataDir(config);
+  const record = { timestamp: new Date().toISOString(), ...entry };
+  await fs.appendFile(config.auditLogPath, `${JSON.stringify(record)}\n`, 'utf8');
+  return record;
+}
+
+export async function readCredentials(config) {
+  try {
+    const raw = await fs.readFile(config.credentialStorePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed.credentials) ? parsed.credentials : [];
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+export async function writeCredentials(config, credentials) {
+  await ensureDataDir(config);
+  await fs.writeFile(config.credentialStorePath, JSON.stringify({ credentials }, null, 2), 'utf8');
+}
+
+export function upsertCredential(credentials, credential) {
+  const index = credentials.findIndex((item) => item.id === credential.id);
+  if (index === -1) return [...credentials, credential];
+  const next = credentials.slice();
+  next[index] = { ...next[index], ...credential };
+  return next;
+}

--- a/server/test/expiry.test.js
+++ b/server/test/expiry.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { findExpiringCredentials, paginate } from '../src/expiry.js';
+
+test('findExpiringCredentials returns credentials inside the warning window', () => {
+  const now = new Date('2026-01-01T00:00:00Z');
+  const credentials = [
+    { id: 'expired', expires_at: 1_767_225_599 },
+    { id: 'soon', expires_at: 1_767_398_400 },
+    { id: 'later', expires_at: 1_768_003_200 },
+    { id: 'never', expires_at: 0 },
+  ];
+
+  assert.deepEqual(findExpiringCredentials(credentials, { windowDays: 7, now }).map((item) => item.id), ['soon']);
+});
+
+test('paginate caps page size and reports total', () => {
+  const page = paginate([1, 2, 3, 4], { page: 2, pageSize: 2 });
+  assert.deepEqual(page, { page: 2, pageSize: 2, total: 4, items: [3, 4] });
+});

--- a/server/test/metrics.test.js
+++ b/server/test/metrics.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { MetricsService } from '../src/metrics.js';
+
+test('metrics service renders Prometheus counters and latency histogram', () => {
+  const metrics = new MetricsService();
+  metrics.applyEvents([
+    { topic: ['DID', 'created'] },
+    { topic: ['CRED', 'issued credential'] },
+    { topic: ['CRED', 'revoked credential'] },
+    { topic: ['SCORE', 'submitted'] },
+  ]);
+  metrics.observeRpcLatency(0.2);
+  const rendered = metrics.renderPrometheus();
+
+  assert.match(rendered, /dids_created_total 1/);
+  assert.match(rendered, /credentials_issued_total 1/);
+  assert.match(rendered, /credentials_revoked_total 1/);
+  assert.match(rendered, /reputation_scores_submitted_total 1/);
+  assert.match(rendered, /soroban_rpc_call_latency_seconds_count 1/);
+});


### PR DESCRIPTION
### Description
- Add a new `server/` package implementing `GET /health`, `GET /metrics`, protected `GET|POST|DELETE /admin/issuers`, and `GET /admin/expiry-report`, plus a background expiry job that indexes events and dispatches webhook notifications; key files: `server/src/{index,app,config,soroban,expiry,metrics,storage,http-utils}.js`. 
- Implement a `SorobanClient` wrapper to call contract methods (used by `/health` and admin wrappers) and a `MetricsAggregator` that indexes Soroban `getEvents` for Prometheus counters/histogram. 
- Add `ping()` read-only function and `CONTRACT_VERSION` constant to the three contracts and include `expires_at` in the `CRED/issued` event so the server can index expiry windows. 
- Add docs and operational tooling: `docs/server-operations.md`, `scripts/post_deploy_health_check.sh`, README updates, and a `workflow_dispatch` CI job to run the post-deploy health check. 
- Wire admin routes to API-key authentication and append-only JSONL audit logging for `add_issuer`/`remove_issuer`. 
- This PR implements fixes/adjustments to contract helpers/tests to support the above and includes a unit test asserting `ping()` versions are exposed. 
- Closes #243. 
- Closes #244.
- Closes #245.
- Closes #246.   

### Testing
- Ran Node syntax checks and server unit tests via `node --check` and `npm test` in `server/`, which passed (3 tests passed). 
- Ran `cargo fmt --check` which passed. 
- Ran contract lifecycle tests via `cargo test --test lifecycle`, and the new `contracts_expose_ping_version` test passed; `contracts/tests/lifecycle.rs` tests passed. 
- Ran full `cargo test` across contracts where most tests passed but the `credential-manager` suite reported 2 failing tests (`test_issue_credential_already_expired`, `test_ttl_not_bumped_on_revoked`) that remain to be investigated and addressed.
