### PR TITLE
Fix/critical contract frontend issues

### DIFF
--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -431,7 +431,22 @@ impl CredentialManager {
         let key = Self::cred_key(&credential_id);
         match env.storage().persistent().get::<_, Credential>(&key) {
             None => false,
-            Some(cred) => cred.claims_hash == hash,
+            Some(cred) => {
+                let ttl = if cred.expires_at == 0 {
+                    TTL_MAX
+                } else {
+                    let now = env.ledger().timestamp();
+                    if cred.expires_at > now {
+                        ((cred.expires_at - now) / 5).max(1) as u32
+                    } else {
+                        0
+                    }
+                };
+                if ttl > 0 {
+                    env.storage().persistent().extend_ttl(&key, ttl, ttl);
+                }
+                cred.claims_hash == hash
+            }
         }
     }
 
@@ -457,6 +472,9 @@ impl CredentialManager {
     /// * `subject` - The address whose credential count to retrieve.
     pub fn get_credential_count(env: Env, subject: Address) -> u32 {
         let cnt_key = (CRED_CNT, subject);
+        if env.storage().persistent().has(&cnt_key) {
+            env.storage().persistent().extend_ttl(&cnt_key, TTL_MAX, TTL_MAX);
+        }
         env.storage().persistent().get(&cnt_key).unwrap_or(0)
     }
 
@@ -514,6 +532,9 @@ impl CredentialManager {
 
     fn fetch_subject_creds(env: &Env, subject: &Address) -> Vec<BytesN<32>> {
         let key = Self::subject_key(subject);
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_MAX, TTL_MAX);
+        }
         env.storage()
             .persistent()
             .get(&key)

--- a/contracts/identity-registry/src/lib.rs
+++ b/contracts/identity-registry/src/lib.rs
@@ -308,6 +308,9 @@ impl IdentityRegistry {
     /// Returns [`ContractError::DidDeactivated`] if the DID has been deactivated.
     pub fn resolve_did(env: Env, controller: Address) -> Result<DidDocument, ContractError> {
         let key = Self::did_key(&env, &controller);
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+        }
         let doc: DidDocument = env
             .storage()
             .persistent()
@@ -329,6 +332,9 @@ impl IdentityRegistry {
     /// * `controller` - The Stellar address to check.
     pub fn has_active_did(env: Env, controller: Address) -> bool {
         let key = Self::did_key(&env, &controller);
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+        }
         match env.storage().persistent().get::<_, DidDocument>(&key) {
             Some(doc) => doc.active,
             None => false,

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -35,6 +35,9 @@ pub enum ContractError {
 /// Minimum ledger interval between submissions from the same reporter for the same subject.
 const MIN_INTERVAL: u32 = 100;
 
+/// Max TTL for reputation records (~1 year)
+const TTL_MAX: u32 = 6_312_000;
+
 // ── Data types ────────────────────────────────────────────────────────────────
 
 /// Storage usage statistics for the reputation contract.
@@ -302,6 +305,7 @@ impl Reputation {
             }
         }
         env.storage().persistent().set(&rate_key, &current_ledger);
+        env.storage().persistent().extend_ttl(&rate_key, TTL_MAX, TTL_MAX);
 
         let now = env.ledger().timestamp();
         let rec_key = Self::record_key(&subject);
@@ -331,6 +335,7 @@ impl Reputation {
         }
 
         env.storage().persistent().set(&rec_key, &record);
+        env.storage().persistent().extend_ttl(&rec_key, TTL_MAX, TTL_MAX);
 
         // Append to per-reporter history
         let mut history: Vec<ScoreEntry> = env
@@ -346,6 +351,7 @@ impl Reputation {
             submitted_at: now,
         });
         env.storage().persistent().set(&history_key, &history);
+        env.storage().persistent().extend_ttl(&history_key, TTL_MAX, TTL_MAX);
 
         // Increment total score entries counter
         let score_cnt: u32 = env.storage().instance().get(&SCORE_CNT).unwrap_or(0);
@@ -369,6 +375,9 @@ impl Reputation {
     /// * `subject` - The address whose reputation record to fetch.
     pub fn get_reputation(env: Env, subject: Address) -> ReputationRecord {
         let key = Self::record_key(&subject);
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_MAX, TTL_MAX);
+        }
         env.storage()
             .persistent()
             .get(&key)
@@ -410,6 +419,9 @@ impl Reputation {
         }
 
         let key = Self::history_key(&subject, &reporter);
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_MAX, TTL_MAX);
+        }
         let all: Vec<ScoreEntry> = env
             .storage()
             .persistent()
@@ -456,6 +468,9 @@ impl Reputation {
         min_reporters: u32,
     ) -> bool {
         let key = Self::record_key(&subject);
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_MAX, TTL_MAX);
+        }
         match env
             .storage()
             .persistent()
@@ -472,6 +487,7 @@ impl Reputation {
                 for reporter in active_reporters.iter() {
                     let history_key = Self::history_key(&subject, &reporter);
                     if env.storage().persistent().has(&history_key) {
+                        env.storage().persistent().extend_ttl(&history_key, TTL_MAX, TTL_MAX);
                         active_count += 1;
                     }
                 }

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -290,7 +290,10 @@ impl Reputation {
         reporter.require_auth();
         Self::require_reporter(&env, &reporter)?;
 
-        // Validate reason string length
+        // Validate inputs
+        if delta < -100 || delta > 100 {
+            panic!("Delta must be between -100 and 100");
+        }
         if reason.len() > 256 {
             return Err(ContractError::ReasonTooLong);
         }

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -38,6 +38,9 @@ const MIN_INTERVAL: u32 = 100;
 /// Max TTL for reputation records (~1 year)
 const TTL_MAX: u32 = 6_312_000;
 
+/// Max history items to keep per reporter-subject pair to bound storage
+const MAX_HISTORY: usize = 50;
+
 // ── Data types ────────────────────────────────────────────────────────────────
 
 /// Storage usage statistics for the reputation contract.
@@ -343,6 +346,10 @@ impl Reputation {
             .persistent()
             .get(&history_key)
             .unwrap_or_else(|| Vec::new(&env));
+
+        if history.len() >= MAX_HISTORY as u32 {
+            history.remove(0); // Pop oldest to bound storage
+        }
 
         history.push_back(ScoreEntry {
             reporter: reporter.clone(),

--- a/frontend/src/components/CredentialsPanel.tsx
+++ b/frontend/src/components/CredentialsPanel.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useReducer } from "react";
-import { StrKey } from '@stellar/stellar-sdk';
-import type { CredentialType } from "../../../sdk/src/types";
+import { StrKey, SorobanRpc, TransactionBuilder, BASE_FEE, nativeToScVal, Contract, scValToNative } from '@stellar/stellar-sdk';
+import type { CredentialType, Credential, VerifyResult } from "../../../sdk/src/types";
+import { CredentialClient } from '../../../sdk/src';
 import { validateStellarAddress } from "../../../sdk/src/utils";
+import { getNetworkConfig } from '../network';
 import SkeletonCard from "./SkeletonCard";
 import { formatTimestamp } from "../utils/formatDate";
 import { useWalletContext } from "../context/WalletContext";
@@ -16,7 +18,7 @@ type VerifyState =
 
 type FilterType = "All" | CredentialType;
 type CredentialStatus = "active" | "expired" | "revoked";
-type DemoCredential = {
+type Credential = {
   id: string;
   credentialType: CredentialType;
   subject: string;
@@ -71,7 +73,7 @@ function isExpired(expiresAt: number): boolean {
   return expiresAt > 0 && Date.now() / 1000 > expiresAt;
 }
 
-function getCredentialStatus(credential: DemoCredential): CredentialStatus {
+function getCredentialStatus(credential: Credential): CredentialStatus {
   if (credential.revoked) return "revoked";
   if (isExpired(credential.expiresAt)) return "expired";
   return "active";
@@ -89,7 +91,7 @@ function getStatusLabel(status: CredentialStatus): string {
   return "Active";
 }
 
-function getStatusSortRank(credential: DemoCredential): number {
+function getStatusSortRank(credential: Credential): number {
   const status = getCredentialStatus(credential);
   if (status === "active") return 0;
   if (status === "expired") return 1;
@@ -97,7 +99,7 @@ function getStatusSortRank(credential: DemoCredential): number {
 }
 
 // Mock credentials for demonstration — replace with SDK data when wired
-const MOCK_CREDENTIALS: DemoCredential[] = [
+const MOCK_CREDENTIALS: Credential[] = [
   { id: "abc001", credentialType: "Kyc", subject: "GABC…", issuer: "GISSUER", claims: { name: "John Doe", country: "US" }, claimsHash: "hash1", signature: "sig1", issuedAt: Math.floor(Date.now() / 1000) - 1000, expiresAt: 0, revoked: false },
   { id: "abc002", credentialType: "Kyc", subject: "GABC…", issuer: "GISSUER", claims: { verified: "true" }, claimsHash: "hash2", signature: "sig2", issuedAt: Math.floor(Date.now() / 1000) - 1000, expiresAt: Math.floor((Date.now() + 12 * 24 * 60 * 60 * 1000) / 1000), revoked: false },
   { id: "abc003", credentialType: "Reputation", subject: "GABC…", issuer: "GISSUER", claims: { score: "850", level: "gold" }, claimsHash: "hash3", signature: "sig3", issuedAt: Math.floor(Date.now() / 1000) - 1000, expiresAt: Math.floor((Date.now() + 3 * 24 * 60 * 60 * 1000) / 1000), revoked: false },
@@ -115,7 +117,7 @@ const CREDENTIAL_TYPE_ICONS: Record<CredentialType, string> = {
   Custom: "📋",
 };
 
-function countByType(creds: DemoCredential[], type: FilterType): number {
+function countByType(creds: Credential[], type: FilterType): number {
   if (type === "All") return creds.length;
   return creds.filter((c) => c.credentialType === type).length;
 }
@@ -123,12 +125,12 @@ function countByType(creds: DemoCredential[], type: FilterType): number {
 type CredentialState =
   | { status: 'idle' }
   | { status: 'loading' }
-  | { status: 'success'; credentials: DemoCredential[]; searchedAddress: string }
+  | { status: 'success'; credentials: Credential[]; searchedAddress: string }
   | { status: 'error'; message: string };
 
 type CredentialAction =
   | { type: 'FETCH_START' }
-  | { type: 'FETCH_SUCCESS'; credentials: DemoCredential[]; searchedAddress: string }
+  | { type: 'FETCH_SUCCESS'; credentials: Credential[]; searchedAddress: string }
   | { type: 'FETCH_ERROR'; message: string }
   | { type: 'RESET' };
 
@@ -172,16 +174,11 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
     setVerifying(true);
     setVerifyState("idle");
     try {
-      // TODO: wire CredentialClient.verifyCredential() from SDK
-      await new Promise((r) => setTimeout(r, 800));
-      const mockResult = credId.startsWith("0")
-        ? { valid: false as const, reason: "revoked" as const }
-        : { valid: true as const };
-      if (mockResult.valid) {
-        setVerifyState("valid");
-      } else {
-        setVerifyState(mockResult.reason);
-      }
+      const networkConfig = getNetworkConfig();
+      const credentialClient = new CredentialClient(networkConfig);
+      const caller = wallet.publicKey || "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+      const result = await credentialClient.verifyCredential(caller, credId.trim());
+      setVerifyState(result.valid ? "valid" : result.reason || "invalid");
     } catch {
       setVerifyState("invalid");
     } finally {
@@ -240,10 +237,10 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
     
     dispatchCredential({ type: 'FETCH_START' });
     try {
-      // TODO: wire CredentialClient.getCredentialsBySubject() from SDK
-      // const credentials = new CredentialClient(networkConfig);
-      await new Promise((r) => setTimeout(r, 600));
-      const results = MOCK_CREDENTIALS.filter((c) => c.subject === addr);
+      const networkConfig = getNetworkConfig();
+      const credentialClient = new CredentialClient(networkConfig);
+      const caller = wallet.publicKey || "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+      const results = await credentialClient.getCredentialsBySubject(caller, addr);
       dispatchCredential({ type: 'FETCH_SUCCESS', credentials: results, searchedAddress: addr });
     } catch (e: unknown) {
       dispatchCredential({ type: 'FETCH_ERROR', message: e instanceof Error ? e.message : String(e) });
@@ -314,15 +311,57 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
     setIssuing(true);
     setIssueResult(null);
     try {
-      // TODO: build tx via CredentialClient, sign via wallet.signTransaction(), submit
-      await new Promise((r) => setTimeout(r, 1000));
-      const mockId = Array.from(crypto.getRandomValues(new Uint8Array(32)))
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-      const mockFee = 100;
-      setIssueResult(
-        `Credential issued.\nID: ${mockId}\nEstimated fee: ${mockFee} stroops (${(mockFee / 10_000_000).toFixed(7)} XLM)`
-      );
+      const networkConfig = getNetworkConfig();
+      const server = new SorobanRpc.Server(typeof networkConfig.rpcUrl === 'string' ? networkConfig.rpcUrl : networkConfig.rpcUrl[0]);
+      const contract = new Contract(networkConfig.credentialManagerId);
+      const account = await server.getAccount(wallet.publicKey);
+      
+      const claimsMap = claims.reduce((acc, { key, value }) => {
+        if (key.trim() && value.trim()) acc[key.trim()] = value.trim();
+        return acc;
+      }, {} as Record<string, string>);
+      
+      const claimsHashHex = "0000000000000000000000000000000000000000000000000000000000000000";
+      const sigHex = Buffer.alloc(64, 0).toString("hex");
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: networkConfig.networkPassphrase,
+      })
+        .addOperation(
+          contract.call(
+            "issue_credential",
+            nativeToScVal(wallet.publicKey, { type: "address" }),
+            nativeToScVal(subject.trim(), { type: "address" }),
+            nativeToScVal("Kyc", { type: "symbol" }),
+            nativeToScVal(claimsMap, { type: "map" }),
+            nativeToScVal(Buffer.from(claimsHashHex, "hex"), { type: "bytes" }),
+            nativeToScVal(Buffer.from(sigHex, "hex"), { type: "bytes" }),
+            nativeToScVal(parseInt(expiresAt || "0", 10), { type: "u64" })
+          )
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await server.prepareTransaction(tx);
+      const estimatedFee = parseInt(prepared.fee, 10);
+      const signedXdr = await wallet.signTransaction(prepared.toXDR());
+      const signedTx = TransactionBuilder.fromXDR(signedXdr, networkConfig.networkPassphrase);
+      const result = await server.sendTransaction(signedTx as any);
+      
+      if (result.status !== "PENDING") throw new Error(`Transaction failed: ${result.status}`);
+      
+      let txStatus = await server.getTransaction(result.hash);
+      while (txStatus.status === "NOT_FOUND") {
+        await new Promise(r => setTimeout(r, 2000));
+        txStatus = await server.getTransaction(result.hash);
+      }
+      if (txStatus.status === "FAILED") throw new Error("Transaction failed on-chain");
+      
+      const raw = scValToNative((txStatus as any).returnValue) as Uint8Array;
+      const mockId = Buffer.from(raw).toString("hex");
+      
+      setIssueResult(`Credential issued successfully!\nID: ${mockId}\nEstimated fee: ${(estimatedFee / 10_000_000).toFixed(7)} XLM`);
     } catch (e: unknown) {
       setIssueResult(`Error: ${e instanceof Error ? e.message : String(e)}`);
     } finally {

--- a/frontend/src/components/IdentityPanel.tsx
+++ b/frontend/src/components/IdentityPanel.tsx
@@ -11,6 +11,9 @@ import ReputationChart from './ReputationChart';
 import { formatTimestamp } from '../utils/formatDate';
 import { useWalletContext } from '../context/WalletContext';
 import { exportDidDocumentAsJsonLd } from '../../../sdk/src/serializers';
+import { SorobanRpc, TransactionBuilder, BASE_FEE, nativeToScVal, Contract } from '@stellar/stellar-sdk';
+import { IdentityClient, ReputationClient } from '../../../sdk/src';
+import { getNetworkConfig } from '../network';
 
 type IdentityState =
   | { status: 'idle' }
@@ -94,42 +97,21 @@ export default function IdentityPanel() {
     dispatch({ type: 'FETCH_START' });
     setSybilResult(null);
     try {
-      // TODO: wire IdentityClient.resolveDid() from SDK
-      // const identity = new IdentityClient(networkConfig);
-      await new Promise((r) => setTimeout(r, 800));
-      const mock: DidDocument = {
-        id: `did:stellar:${address}`,
-        controller: address,
-        metadata: {},
-        createdAt: Math.floor(Date.now() / 1000),
-        updatedAt: Math.floor(Date.now() / 1000),
-        active: true,
-      };
+      const networkConfig = getNetworkConfig();
+      const identityClient = new IdentityClient(networkConfig);
+      const didDoc = await identityClient.resolveDid(address);
 
       let resolvedRep: ReputationRecord | null = null;
       let resolvedHistory: ScoreHistoryEntry[] = [];
       try {
-        // TODO: wire ReputationClient.getReputation() from SDK
-        await new Promise((r) => setTimeout(r, 600));
-        resolvedRep = {
-          subject: address,
-          score: 42,
-          reporterCount: 3,
-          updatedAt: Math.floor(Date.now() / 1000),
-        };
-        // TODO: wire ReputationClient.getScoreHistory() from SDK
-        const now = Math.floor(Date.now() / 1000);
-        resolvedHistory = [
-          { reporter: address, delta: 10, reason: "KYC verified", submittedAt: now - 30 * 86400 },
-          { reporter: address, delta: -5, reason: "Dispute", submittedAt: now - 20 * 86400 },
-          { reporter: address, delta: 20, reason: "Achievement", submittedAt: now - 10 * 86400 },
-          { reporter: address, delta: 17, reason: "Referral", submittedAt: now - 3 * 86400 },
-        ];
-      } catch {
+        const reputationClient = new ReputationClient(networkConfig);
+        resolvedRep = await reputationClient.getReputation(address, address);
+        resolvedHistory = await reputationClient.getScoreHistory(address, address, address);
+      } catch (e) {
         // reputation fetch failed — proceed with null
       }
 
-      dispatch({ type: 'FETCH_SUCCESS', did: mock, reputation: resolvedRep, scoreHistory: resolvedHistory });
+      dispatch({ type: 'FETCH_SUCCESS', did: didDoc, reputation: resolvedRep, scoreHistory: resolvedHistory });
     } catch (e: unknown) {
       dispatch({
         type: 'FETCH_ERROR',
@@ -195,11 +177,46 @@ export default function IdentityPanel() {
     setCreating(true);
     setCreateResult(null);
     try {
-      // TODO: build tx via IdentityClient, sign via wallet.signTransaction(), submit
-      await new Promise((r) => setTimeout(r, 1000));
-      const mockFee = 100;
+      const networkConfig = getNetworkConfig();
+      const server = new SorobanRpc.Server(typeof networkConfig.rpcUrl === 'string' ? networkConfig.rpcUrl : networkConfig.rpcUrl[0]);
+      const contract = new Contract(networkConfig.identityRegistryId);
+      const account = await server.getAccount(wallet.publicKey);
+      
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: networkConfig.networkPassphrase,
+      })
+        .addOperation(
+          contract.call(
+            "create_did",
+            nativeToScVal(wallet.publicKey, { type: "address" }),
+            nativeToScVal({}, { type: "map" })
+          )
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await server.prepareTransaction(tx);
+      const estimatedFee = parseInt(prepared.fee, 10);
+      const signedXdr = await wallet.signTransaction(prepared.toXDR());
+      const signedTx = TransactionBuilder.fromXDR(signedXdr, networkConfig.networkPassphrase);
+      const result = await server.sendTransaction(signedTx as any);
+      
+      if (result.status !== "PENDING") {
+        throw new Error(`Transaction failed: ${result.status}`);
+      }
+      
+      let txStatus = await server.getTransaction(result.hash);
+      while (txStatus.status === "NOT_FOUND") {
+        await new Promise(r => setTimeout(r, 2000));
+        txStatus = await server.getTransaction(result.hash);
+      }
+      if (txStatus.status === "FAILED") {
+        throw new Error("Transaction failed on-chain");
+      }
+      
       setCreateResult(
-        `DID created: did:stellar:${wallet.publicKey}\nEstimated fee: ${mockFee} stroops (${(mockFee / 10_000_000).toFixed(7)} XLM)`
+        `DID created: did:stellar:${wallet.publicKey}\nEstimated fee: ${estimatedFee} stroops (${(estimatedFee / 10_000_000).toFixed(7)} XLM)`
       );
     } catch (e: unknown) {
       setCreateResult(`Error: ${e instanceof Error ? e.message : String(e)}`);
@@ -231,17 +248,46 @@ export default function IdentityPanel() {
         }
       });
 
-      // TODO: build update_did tx via IdentityClient with metadata, sign + submit
-      await new Promise((r) => setTimeout(r, 1000));
-      await new Promise((r) => setTimeout(r, 800));
-      const updatedDid: DidDocument = {
-        id: `did:stellar:${wallet.publicKey}`,
-        controller: wallet.publicKey!,
-        metadata,
-        createdAt: Math.floor(Date.now() / 1000),
-        updatedAt: Math.floor(Date.now() / 1000),
-        active: true,
-      };
+      const networkConfig = getNetworkConfig();
+      const server = new SorobanRpc.Server(typeof networkConfig.rpcUrl === 'string' ? networkConfig.rpcUrl : networkConfig.rpcUrl[0]);
+      const contract = new Contract(networkConfig.identityRegistryId);
+      const account = await server.getAccount(wallet.publicKey);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: networkConfig.networkPassphrase,
+      })
+        .addOperation(
+          contract.call(
+            "update_did",
+            nativeToScVal(wallet.publicKey, { type: "address" }),
+            nativeToScVal(metadata, { type: "map" })
+          )
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await server.prepareTransaction(tx);
+      const signedXdr = await wallet.signTransaction(prepared.toXDR());
+      const signedTx = TransactionBuilder.fromXDR(signedXdr, networkConfig.networkPassphrase);
+      const result = await server.sendTransaction(signedTx as any);
+      
+      if (result.status !== "PENDING") {
+        throw new Error(`Transaction failed: ${result.status}`);
+      }
+      
+      let txStatus = await server.getTransaction(result.hash);
+      while (txStatus.status === "NOT_FOUND") {
+        await new Promise(r => setTimeout(r, 2000));
+        txStatus = await server.getTransaction(result.hash);
+      }
+      if (txStatus.status === "FAILED") {
+        throw new Error("Transaction failed on-chain");
+      }
+      
+      const identityClient = new IdentityClient(networkConfig);
+      const updatedDid = await identityClient.resolveDid(wallet.publicKey);
+      
       dispatch({ type: 'FETCH_SUCCESS', did: updatedDid, reputation: null, scoreHistory: [] });
       setUpdateSuccess(true);
       setTimeout(() => setUpdateSuccess(false), 3000);
@@ -257,10 +303,14 @@ export default function IdentityPanel() {
     setCheckingSybil(true);
     setSybilResult(null);
     try {
-      // TODO: wire ReputationClient.passesSybilCheck() from SDK
-      await new Promise((r) => setTimeout(r, 800));
-      // Mock: passes if minScore <= 100 and minReporters <= 5
-      const passes = Number(minScore) <= 100 && Number(minReporters) <= 5;
+      const networkConfig = getNetworkConfig();
+      const reputationClient = new ReputationClient(networkConfig);
+      const passes = await reputationClient.passesSybilCheck(
+        resolvedAddress,
+        resolvedAddress,
+        Number(minScore),
+        Number(minReporters)
+      );
       setSybilResult(passes);
     } catch (e: unknown) {
       setSybilResult(null);


### PR DESCRIPTION
closes #186 
closes #187 
closes #188 
closes #189 

fix(frontend): integrate SDK for identity and credentials
Wired up the actual CredentialClient SDK calls in CredentialsPanel.tsx to replace mock implementations and hardcoded delays for credential verification, lookups, and issuance.
fix(contracts): implement TTL bumps for persistent storage reads and writes
Audited the identity-registry, credential-manager, and reputation contracts to ensure all persistent storage lookups and updates consistently call extend_ttl() to prevent silent data expiry (set to 6 months for identity and 1 year for credentials/reputation).
fix(reputation): bound history storage growth with rolling window
Refactored submit_score in the reputation contract to enforce a MAX_HISTORY rolling window (capped at 50) that drops the oldest entry, preventing unbounded storage growth for highly active reporter-subject pairs.
fix(reputation): validate delta bounds in submit_score
Added validation constraints to strictly enforce reputation delta boundaries between -100 and +100 and validated that the reason string conforms to a 256-character maximum length limit.