### PR TITLE
fix: CI pipeline, SDK npm publishing, contract upgrade path, and health check

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -62,3 +62,33 @@ jobs:
       - name: Type check
         working-directory: frontend
         run: npx tsc --noEmit
+
+  frontend-build:
+    name: Frontend — build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install SDK dependencies
+        working-directory: sdk
+        run: npm ci
+
+      - name: Build SDK
+        working-directory: sdk
+        run: npm run build
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build

--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -1,8 +1,7 @@
 #![no_std]
 
-use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, xdr::ToXdr, Address, Bytes,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes,
     BytesN, Env, Map, String, Symbol, Vec,
 };
 use soroban_sdk::xdr::ToXdr;
@@ -788,6 +787,33 @@ mod tests {
     }
 
     #[test]
+    fn test_ping_returns_version() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, CredentialManager);
+        let client = CredentialManagerClient::new(&env, &contract_id);
+        assert_eq!(client.ping(), CONTRACT_VERSION);
+    }
+
+    #[test]
+    fn test_upgrade_unauthorized_returns_error() {
+        let (env, admin, client) = setup();
+        let attacker = Address::generate(&env);
+        let result = client.try_upgrade(&attacker, &BytesN::from_array(&env, &[0u8; 32]));
+        assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_upgrade_not_initialized_returns_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, CredentialManager);
+        let client = CredentialManagerClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let result = client.try_upgrade(&admin, &BytesN::from_array(&env, &[0u8; 32]));
+        assert_eq!(result, Err(Ok(ContractError::NotInitialized)));
+    }
+
+    #[test]
     fn test_issue_and_verify() {
         let (env, _admin, client) = setup();
         let issuer = Address::generate(&env);
@@ -811,16 +837,17 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_issue_credential_already_expired() {
         let (env, _admin, client) = setup();
         let issuer = Address::generate(&env);
         let subject = Address::generate(&env);
         client.add_issuer(&issuer);
 
-        let past_expiry = env.ledger().timestamp().saturating_sub(1);
+        // Advance ledger so timestamp > 0, then use a strictly past expiry
+        env.ledger().with_mut(|li| li.timestamp = 100);
+        let past_expiry = 50u64;
         let sig = Bytes::from_array(&env, &[0u8; 64]);
-        client.issue_credential(
+        let result = client.try_issue_credential(
             &issuer,
             &subject,
             &CredentialType::Kyc,
@@ -829,6 +856,7 @@ mod tests {
             &sig,
             &past_expiry,
         );
+        assert_eq!(result, Err(Ok(ContractError::CredentialExpired)));
     }
 
     #[test]
@@ -1171,9 +1199,9 @@ mod tests {
         // verify_credential returns false for revoked — no TTL bump
         assert!(!client.verify_credential(&cred_id));
 
-        // get_credential still returns the record (not extended)
-        let cred = client.get_credential(&cred_id);
-        assert!(cred.revoked);
+        // get_credential returns CredentialRevoked for revoked entries
+        let result = client.try_get_credential(&cred_id);
+        assert!(matches!(result, Err(Ok(ContractError::CredentialRevoked))));
     }
 
     fn issue_typed(

--- a/contracts/identity-registry/src/lib.rs
+++ b/contracts/identity-registry/src/lib.rs
@@ -447,6 +447,41 @@ mod tests {
     use std::string::ToString;
 
     #[test]
+    fn test_ping_returns_version() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, IdentityRegistry);
+        let client = IdentityRegistryClient::new(&env, &contract_id);
+        assert_eq!(client.ping(), CONTRACT_VERSION);
+    }
+
+    #[test]
+    fn test_upgrade_unauthorized_returns_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, IdentityRegistry);
+        let client = IdentityRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        client.initialize(&admin);
+
+        let result = client.try_upgrade(&attacker, &BytesN::from_array(&env, &[0u8; 32]));
+        assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_upgrade_not_initialized_returns_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, IdentityRegistry);
+        let client = IdentityRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let result = client.try_upgrade(&admin, &BytesN::from_array(&env, &[0u8; 32]));
+        assert_eq!(result, Err(Ok(ContractError::NotInitialized)));
+    }
+
+    #[test]
     fn test_double_initialize_returns_error() {
         let env = Env::default();
         env.mock_all_auths();

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -725,6 +725,41 @@ mod tests {
     };
 
     #[test]
+    fn test_ping_returns_version() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, Reputation);
+        let client = ReputationClient::new(&env, &contract_id);
+        assert_eq!(client.ping(), CONTRACT_VERSION);
+    }
+
+    #[test]
+    fn test_upgrade_unauthorized_returns_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, Reputation);
+        let client = ReputationClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        client.initialize(&admin);
+
+        let result = client.try_upgrade(&attacker, &BytesN::from_array(&env, &[0u8; 32]));
+        assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_upgrade_not_initialized_returns_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, Reputation);
+        let client = ReputationClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let result = client.try_upgrade(&admin, &BytesN::from_array(&env, &[0u8; 32]));
+        assert_eq!(result, Err(Ok(ContractError::NotInitialized)));
+    }
+
+    #[test]
     fn test_double_initialize_returns_error() {
         let env = Env::default();
         env.mock_all_auths();
@@ -913,7 +948,7 @@ mod tests {
         client.add_reporter(&reporter);
 
         let reason = String::from_str(&env, "penalty");
-        client.submit_score(&reporter, &subject, &-9_999_999, &reason);
+        client.submit_score(&reporter, &subject, &-100, &reason);
 
         let rec = client.get_reputation(&subject);
         assert_eq!(rec.score, 0);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^0.9.5",
-    "@soroban-identity/sdk": "file:../sdk",
+    "@soroban-identity/sdk": "^0.1.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "@walletconnect/sign-client": "^2.17.0",
     "i18next": "^26.0.7",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "soroban-identity-monorepo",
+  "private": true,
+  "workspaces": [
+    "sdk",
+    "frontend"
+  ]
+}

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -5,6 +5,22 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -1,4 +1,5 @@
 import {
+  Account,
   Contract,
   SorobanRpc,
   TransactionBuilder,
@@ -739,5 +740,38 @@ export class CredentialClient extends BaseClient {
     ) as { items: string[]; next_cursor: number | null };
 
     return { items: raw.items, nextCursor: raw.next_cursor ?? null };
+  }
+
+  /**
+   * Liveness probe — calls the on-chain `ping()` function.
+   *
+   * Returns the contract's `CONTRACT_VERSION` constant. Throws if the contract
+   * is not deployed or not responding.
+   *
+   * @param options Per-call overrides (currently `timeoutSeconds`).
+   * @returns The contract version number (currently `1`).
+   * @throws {SorobanIdentityError} with code `CONTRACT_ERROR` if the contract
+   *   does not respond.
+   */
+  async ping(options?: CallOptions): Promise<number> {
+    const account = new Account(PROBE_ADDRESS, "0");
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(this.contract.call("ping"))
+      .setTimeout(timeout)
+      .build();
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
+    if (SorobanRpc.Api.isSimulationError(result)) {
+      throw new SorobanIdentityError(
+        "Health check failed: credential-manager not responding",
+        "CONTRACT_ERROR"
+      );
+    }
+    return scValToNative(
+      (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval
+    ) as number;
   }
 }

--- a/sdk/src/health.ts
+++ b/sdk/src/health.ts
@@ -1,0 +1,50 @@
+import { IdentityClient } from './identity';
+import { CredentialClient } from './credentials';
+import { ReputationClient } from './reputation';
+import type { SorobanIdentityConfig } from './types';
+
+export interface HealthCheckResult {
+  identityRegistry: boolean;
+  credentialManager: boolean;
+  reputation: boolean;
+  allHealthy: boolean;
+}
+
+/**
+ * Pre-flight health check that pings all three deployed contracts.
+ *
+ * Calls the read-only `ping()` function on each contract in parallel and
+ * returns a per-contract boolean indicating whether it responded. Use this
+ * before initiating user-facing operations to surface deployment problems
+ * early.
+ *
+ * @param config SDK config with all three contract IDs populated.
+ * @returns {@link HealthCheckResult} with individual and aggregate liveness
+ *   flags. A contract is considered unhealthy if its `ping()` throws for any
+ *   reason (network error, contract not deployed, not initialised, etc.).
+ *
+ * @example
+ * ```ts
+ * import { healthCheck, TESTNET_CONFIG } from '@soroban-identity/sdk';
+ * const { allHealthy } = await healthCheck({ ...TESTNET_CONFIG, ... });
+ * if (!allHealthy) throw new Error('One or more contracts are not reachable');
+ * ```
+ */
+export async function healthCheck(config: SorobanIdentityConfig): Promise<HealthCheckResult> {
+  const [identityResult, credentialResult, reputationResult] = await Promise.allSettled([
+    new IdentityClient(config).ping(),
+    new CredentialClient(config).ping(),
+    new ReputationClient(config).ping(),
+  ]);
+
+  const identityOk = identityResult.status === 'fulfilled';
+  const credentialOk = credentialResult.status === 'fulfilled';
+  const reputationOk = reputationResult.status === 'fulfilled';
+
+  return {
+    identityRegistry: identityOk,
+    credentialManager: credentialOk,
+    reputation: reputationOk,
+    allHealthy: identityOk && credentialOk && reputationOk,
+  };
+}

--- a/sdk/src/identity.ts
+++ b/sdk/src/identity.ts
@@ -436,4 +436,37 @@ export class IdentityClient extends BaseClient {
       (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval
     ) as IdentityStorageStats;
   }
+
+  /**
+   * Liveness probe — calls the on-chain `ping()` function.
+   *
+   * Returns the contract's `CONTRACT_VERSION` constant. Throws if the contract
+   * is not deployed or not responding.
+   *
+   * @param options Per-call overrides (currently `timeoutSeconds`).
+   * @returns The contract version number (currently `1`).
+   * @throws {SorobanIdentityError} with code `CONTRACT_ERROR` if the contract
+   *   does not respond.
+   */
+  async ping(options?: CallOptions): Promise<number> {
+    const account = new Account(PROBE_ADDRESS, "0");
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(this.contract.call("ping"))
+      .setTimeout(timeout)
+      .build();
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
+    if (SorobanRpc.Api.isSimulationError(result)) {
+      throw new SorobanIdentityError(
+        "Health check failed: identity-registry not responding",
+        "CONTRACT_ERROR"
+      );
+    }
+    return scValToNative(
+      (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval
+    ) as number;
+  }
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,4 +1,6 @@
 export { IdentityClient } from './identity';
+export { healthCheck } from './health';
+export type { HealthCheckResult } from './health';
 export { CredentialClient } from './credentials';
 export { ReputationClient } from './reputation';
 export { SorobanEventListener, getEvents } from './events';

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -1,4 +1,5 @@
 import {
+  Account,
   Contract,
   SorobanRpc,
   TransactionBuilder,
@@ -607,5 +608,38 @@ export class ReputationClient extends BaseClient {
     ) as { items: ScoreHistoryEntry[]; next_cursor: number | null };
 
     return { items: raw.items, nextCursor: raw.next_cursor ?? null };
+  }
+
+  /**
+   * Liveness probe — calls the on-chain `ping()` function.
+   *
+   * Returns the contract's `CONTRACT_VERSION` constant. Throws if the contract
+   * is not deployed or not responding.
+   *
+   * @param options Per-call overrides (currently `timeoutSeconds`).
+   * @returns The contract version number (currently `1`).
+   * @throws {SorobanIdentityError} with code `CONTRACT_ERROR` if the contract
+   *   does not respond.
+   */
+  async ping(options?: CallOptions): Promise<number> {
+    const account = new Account(PROBE_ADDRESS, "0");
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(this.contract.call("ping"))
+      .setTimeout(timeout)
+      .build();
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
+    if (SorobanRpc.Api.isSimulationError(result)) {
+      throw new SorobanIdentityError(
+        "Health check failed: reputation contract not responding",
+        "CONTRACT_ERROR"
+      );
+    }
+    return scValToNative(
+      (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval
+    ) as number;
   }
 }


### PR DESCRIPTION
## Summary

- **#208** — Add `frontend-build` job to `sdk-ci.yml` that runs `npm run build` for the frontend on every push and PR, closing the gap where no automated frontend build check existed.
- **#207** — Prepare SDK for npm publishing (`exports`, `files`, `publishConfig` fields); add root `package.json` with npm workspaces; switch frontend dependency from `file:../sdk` to `^0.1.0` so it works in any CI or deployment environment without a local monorepo layout.
- **#209** — Fix duplicate `use soroban_sdk::xdr::ToXdr` imports in `credential-manager` (compile error); add `ping()` and `upgrade()` auth tests to all three contracts; fix three pre-existing broken tests (`test_issue_credential_already_expired`, `test_ttl_not_bumped_on_revoked`, `test_score_floor_at_zero`).
- **#210** — Add `ping()` liveness method to `IdentityClient`, `CredentialClient`, and `ReputationClient`; add `sdk/src/health.ts` with a `healthCheck(config)` function that pings all three contracts in parallel and returns a per-contract + aggregate liveness result; export both from the SDK index.

## Test plan

- [ ] `cargo test --workspace` inside `contracts/` — all 64 tests pass
- [ ] `npm run build` inside `sdk/` compiles without errors
- [ ] `npm test` inside `sdk/` passes all existing unit tests
- [ ] `npm run build` inside `frontend/` produces a production bundle
- [ ] CI `contracts-ci.yml` and `sdk-ci.yml` (including new `frontend-build` job) go green

Closes #208
Closes #207
Closes #209
Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)