### PR TITLE
refactor: convert IdentityPanel and CredentialsPanel to use shared FormField

### DIFF
--- a/frontend/src/components/CredentialsPanel.tsx
+++ b/frontend/src/components/CredentialsPanel.tsx
@@ -5,6 +5,7 @@ import { CredentialClient } from '../../../sdk/src';
 import { validateStellarAddress } from "../../../sdk/src/utils";
 import { getNetworkConfig } from '../network';
 import SkeletonCard from "./SkeletonCard";
+import FormField from "./FormField";
 import { formatTimestamp } from "../utils/formatDate";
 import { useWalletContext } from "../context/WalletContext";
 
@@ -590,24 +591,14 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
                 </span>
               </p>
               
-              <div style={{ marginBottom: "1rem" }}>
-                <label style={{ display: "block", marginBottom: "0.5rem", fontSize: "0.85rem", fontWeight: 600 }}>
-                  Subject Address
-                </label>
-                <input
-                  placeholder="Subject address (G…)"
-                  value={subject}
-                  onChange={(e) => setSubject(e.target.value)}
-                  style={{
-                    borderColor: issueErrors.subject ? "var(--error)" : undefined,
-                  }}
-                />
-                {issueErrors.subject && (
-                  <p style={{ color: "var(--error)", fontSize: "0.75rem", marginTop: "0.25rem" }}>
-                    {issueErrors.subject}
-                  </p>
-                )}
-              </div>
+              <FormField
+                label="Subject Address"
+                placeholder="Subject address (G…)"
+                value={subject}
+                onChange={(e) => setSubject(e.target.value)}
+                error={issueErrors.subject}
+                style={{ marginBottom: "1rem" }}
+              />
 
               <div style={{ marginBottom: "1rem" }}>
                 <label style={{ display: "block", marginBottom: "0.5rem", fontSize: "0.85rem", fontWeight: 600 }}>
@@ -666,25 +657,15 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
                 )}
               </div>
 
-              <div style={{ marginBottom: "1rem" }}>
-                <label style={{ display: "block", marginBottom: "0.5rem", fontSize: "0.85rem", fontWeight: 600 }}>
-                  Expires At (Unix timestamp, 0 for no expiry)
-                </label>
-                <input
-                  type="number"
-                  placeholder="0"
-                  value={expiresAt}
-                  onChange={(e) => setExpiresAt(e.target.value)}
-                  style={{
-                    borderColor: issueErrors.expiresAt ? "var(--error)" : undefined,
-                  }}
-                />
-                {issueErrors.expiresAt && (
-                  <p style={{ color: "var(--error)", fontSize: "0.75rem", marginTop: "0.25rem" }}>
-                    {issueErrors.expiresAt}
-                  </p>
-                )}
-              </div>
+              <FormField
+                label="Expires At (Unix timestamp, 0 for no expiry)"
+                type="number"
+                placeholder="0"
+                value={expiresAt}
+                onChange={(e) => setExpiresAt(e.target.value)}
+                error={issueErrors.expiresAt}
+                style={{ marginBottom: "1rem" }}
+              />
 
               <button onClick={handleIssue} disabled={issuing || Object.keys(issueErrors).length > 0}>
                 {issuing ? "Issuing…" : "Issue KYC Credential"}

--- a/frontend/src/components/FormField.tsx
+++ b/frontend/src/components/FormField.tsx
@@ -1,0 +1,68 @@
+import { useId, type ChangeEventHandler, type CSSProperties } from 'react';
+
+export interface FormFieldProps {
+  label: string;
+  value: string;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  placeholder?: string;
+  error?: string;
+  type?: 'text' | 'number';
+  min?: number;
+  id?: string;
+  style?: CSSProperties;
+}
+
+export default function FormField({
+  label,
+  value,
+  onChange,
+  placeholder,
+  error,
+  type = 'text',
+  min,
+  id: idProp,
+  style,
+}: FormFieldProps) {
+  const generatedId = useId();
+  const inputId = idProp ?? generatedId;
+
+  return (
+    <div style={style}>
+      <label
+        htmlFor={inputId}
+        style={{
+          display: 'block',
+          marginBottom: '0.5rem',
+          fontSize: '0.85rem',
+          fontWeight: 600,
+          color: 'var(--text-muted)',
+        }}
+      >
+        {label}
+      </label>
+      <input
+        id={inputId}
+        type={type}
+        min={min}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        aria-invalid={error ? 'true' : undefined}
+        aria-describedby={error ? `${inputId}-error` : undefined}
+        style={{
+          width: '100%',
+          borderColor: error ? 'var(--error)' : undefined,
+        }}
+      />
+      {error && (
+        <p
+          id={`${inputId}-error`}
+          role="alert"
+          style={{ color: 'var(--error)', fontSize: '0.75rem', marginTop: '0.25rem' }}
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/IdentityPanel.tsx
+++ b/frontend/src/components/IdentityPanel.tsx
@@ -7,6 +7,7 @@ import type { ScoreHistoryEntry } from '../../../sdk/src/reputation';
 import type { DidDocument } from '../../../sdk/src/types';
 import { useAddressHistory } from '../hooks/useAddressHistory';
 import SkeletonCard from './SkeletonCard';
+import FormField from './FormField';
 import ReputationChart from './ReputationChart';
 import { formatTimestamp } from '../utils/formatDate';
 import { useWalletContext } from '../context/WalletContext';
@@ -490,30 +491,22 @@ export default function IdentityPanel() {
               </span>
             </p>
             <div style={{ display: 'flex', gap: '0.75rem', marginBottom: '1rem' }}>
-              <div style={{ flex: 1 }}>
-                <label style={{ display: 'block', color: 'var(--text-muted)', fontSize: '0.8rem', marginBottom: '0.25rem' }}>
-                  Min Score
-                </label>
-                <input
-                  type="number"
-                  min={0}
-                  value={minScore}
-                  onChange={(e) => setMinScore(e.target.value)}
-                  style={{ width: '100%' }}
-                />
-              </div>
-              <div style={{ flex: 1 }}>
-                <label style={{ display: 'block', color: 'var(--text-muted)', fontSize: '0.8rem', marginBottom: '0.25rem' }}>
-                  Min Reporters
-                </label>
-                <input
-                  type="number"
-                  min={1}
-                  value={minReporters}
-                  onChange={(e) => setMinReporters(e.target.value)}
-                  style={{ width: '100%' }}
-                />
-              </div>
+              <FormField
+                label="Min Score"
+                type="number"
+                min={0}
+                value={minScore}
+                onChange={(e) => setMinScore(e.target.value)}
+                style={{ flex: 1 }}
+              />
+              <FormField
+                label="Min Reporters"
+                type="number"
+                min={1}
+                value={minReporters}
+                onChange={(e) => setMinReporters(e.target.value)}
+                style={{ flex: 1 }}
+              />
             </div>
             <button onClick={handleSybilCheck} disabled={checkingsSybil}>
               {checkingsSybil ? 'Checking…' : 'Run Sybil Check'}


### PR DESCRIPTION
## Summary
Extract a shared `FormField` component and use it for labelled inputs in `IdentityPanel` and `CredentialsPanel`, removing duplicated label/input markup.

## Purpose / Motivation
Both panels rendered labelled text inputs with nearly identical markup and styling. Any change to input appearance or accessibility had to be duplicated. A shared component centralizes styling, error display, and keyboard accessibility.

## Changes Made
- Add `frontend/src/components/FormField.tsx` with `label`, `value`, `onChange`, `placeholder`, optional `error`, `type`, and `min` props
- Wire `htmlFor` / `id` via `useId()` for keyboard accessibility; expose optional `id` override
- Show validation errors with `aria-invalid`, `aria-describedby`, and `role="alert"`
- Replace Anti-Sybil fields (Min Score, Min Reporters) in `IdentityPanel`
- Replace Issue Credential fields (Subject Address, Expires At) in `CredentialsPanel`
- Claims key-value rows are unchanged (multi-input layout, not a single labelled field)

## How to Test
1. Start the frontend dev server and open the Identity and Credentials tabs.
2. Resolve a DID, then confirm the Anti-Sybil **Min Score** and **Min Reporters** fields render and accept input.
3. Click **Run Sybil Check** and verify behavior is unchanged.
4. Connect a wallet on the Credentials tab, open **Issue Credential**, and confirm **Subject Address** and **Expires At** render with labels.
5. Submit the issue form with invalid values (empty subject, bad address, past expiry) and confirm error messages appear under the fields with a red border.
6. Click each label and confirm focus moves to the associated input (keyboard accessibility).

## Screenshots (if applicable)
N/A — visual appearance is intentionally preserved; styling is unified to the existing Credentials panel label style.

## Breaking Changes
- None.

## Related Issues
Closes El-Chapo-Npm/Soroban-Identity#238

## Checklist
- [x] Code builds successfully
- [ ] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)