### PR TITLE
refactor(frontend): centralize SDK error handling for panels

### DIFF
--- a/frontend/src/components/CredentialsPanel.tsx
+++ b/frontend/src/components/CredentialsPanel.tsx
@@ -6,6 +6,7 @@ import { validateStellarAddress } from "../../../sdk/src/utils";
 import { getNetworkConfig } from '../network';
 import SkeletonCard from "./SkeletonCard";
 import { formatTimestamp } from "../utils/formatDate";
+import { handleError } from "../utils/handleError";
 import { useWalletContext } from "../context/WalletContext";
 
 type VerifyState =
@@ -243,7 +244,7 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
       const results = await credentialClient.getCredentialsBySubject(caller, addr);
       dispatchCredential({ type: 'FETCH_SUCCESS', credentials: results, searchedAddress: addr });
     } catch (e: unknown) {
-      dispatchCredential({ type: 'FETCH_ERROR', message: e instanceof Error ? e.message : String(e) });
+      dispatchCredential({ type: 'FETCH_ERROR', message: handleError(e) });
     }
   };
 
@@ -363,7 +364,7 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
       
       setIssueResult(`Credential issued successfully!\nID: ${mockId}\nEstimated fee: ${(estimatedFee / 10_000_000).toFixed(7)} XLM`);
     } catch (e: unknown) {
-      setIssueResult(`Error: ${e instanceof Error ? e.message : String(e)}`);
+      setIssueResult(`Error: ${handleError(e)}`);
     } finally {
       setIssuing(false);
     }

--- a/frontend/src/components/IdentityPanel.tsx
+++ b/frontend/src/components/IdentityPanel.tsx
@@ -9,6 +9,7 @@ import { useAddressHistory } from '../hooks/useAddressHistory';
 import SkeletonCard from './SkeletonCard';
 import ReputationChart from './ReputationChart';
 import { formatTimestamp } from '../utils/formatDate';
+import { handleError, isNetworkError } from '../utils/handleError';
 import { useWalletContext } from '../context/WalletContext';
 import { exportDidDocumentAsJsonLd } from '../../../sdk/src/serializers';
 import { SorobanRpc, TransactionBuilder, BASE_FEE, nativeToScVal, Contract } from '@stellar/stellar-sdk';
@@ -71,14 +72,6 @@ export default function IdentityPanel() {
   const [showQr, setShowQr] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const isNetworkError = (error: unknown): boolean => {
-    if (error instanceof TypeError) {
-      return error.message.includes("fetch") || error.message.includes("network");
-    }
-    const msg = error instanceof Error ? error.message : String(error);
-    return msg.includes("ECONNREFUSED") || msg.includes("unreachable") || msg.includes("timeout");
-  };
-
   const handleResolve = async () => {
     const address = resolveAddress.trim();
     if (!address) return;
@@ -115,9 +108,7 @@ export default function IdentityPanel() {
     } catch (e: unknown) {
       dispatch({
         type: 'FETCH_ERROR',
-        message: isNetworkError(e)
-          ? "Unable to reach the Soroban network. Please try again later."
-          : (e instanceof Error ? e.message : String(e)),
+        message: handleError(e),
         errorType: isNetworkError(e) ? 'network' : 'contract',
       });
     }
@@ -219,7 +210,7 @@ export default function IdentityPanel() {
         `DID created: did:stellar:${wallet.publicKey}\nEstimated fee: ${estimatedFee} stroops (${(estimatedFee / 10_000_000).toFixed(7)} XLM)`
       );
     } catch (e: unknown) {
-      setCreateResult(`Error: ${e instanceof Error ? e.message : String(e)}`);
+      setCreateResult(`Error: ${handleError(e)}`);
     } finally {
       setCreating(false);
     }
@@ -292,7 +283,7 @@ export default function IdentityPanel() {
       setUpdateSuccess(true);
       setTimeout(() => setUpdateSuccess(false), 3000);
     } catch (e: unknown) {
-      setCreateResult(`Error: ${e instanceof Error ? e.message : String(e)}`);
+      setCreateResult(`Error: ${handleError(e)}`);
     } finally {
       setUpdating(false);
     }

--- a/frontend/src/utils/handleError.ts
+++ b/frontend/src/utils/handleError.ts
@@ -1,0 +1,56 @@
+import {
+  SorobanIdentityError,
+  type SorobanErrorCode,
+} from '../../../sdk/src/errors';
+
+const CODE_MESSAGES: Record<SorobanErrorCode, string> = {
+  NOT_FOUND: 'The requested record was not found.',
+  UNAUTHORIZED: 'You are not authorized to perform this action.',
+  NETWORK_ERROR: 'Unable to reach the Soroban network. Please try again later.',
+  VALIDATION_ERROR: 'Invalid input. Please check your data and try again.',
+  CONTRACT_ERROR: 'The contract rejected this operation. Please try again.',
+  UNKNOWN: 'An unexpected error occurred. Please try again.',
+};
+
+export function isNetworkError(error: unknown): boolean {
+  if (error instanceof SorobanIdentityError) {
+    return error.code === 'NETWORK_ERROR';
+  }
+  if (error instanceof TypeError) {
+    return error.message.includes('fetch') || error.message.includes('network');
+  }
+  const msg = error instanceof Error ? error.message : String(error);
+  return (
+    msg.includes('ECONNREFUSED') ||
+    msg.includes('unreachable') ||
+    msg.includes('timeout')
+  );
+}
+
+function messageForSorobanError(error: SorobanIdentityError): string {
+  if (error.code === 'NOT_FOUND' || error.code === 'VALIDATION_ERROR') {
+    return error.message;
+  }
+  return CODE_MESSAGES[error.code];
+}
+
+/**
+ * Normalizes SDK and runtime errors into a user-facing display string.
+ * Unexpected non-Error values are logged to the console.
+ */
+export function handleError(error: unknown): string {
+  if (error instanceof SorobanIdentityError) {
+    return messageForSorobanError(error);
+  }
+
+  if (isNetworkError(error)) {
+    return CODE_MESSAGES.NETWORK_ERROR;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  console.error('Unexpected error:', error);
+  return CODE_MESSAGES.UNKNOWN;
+}


### PR DESCRIPTION
## Summary
Adds a centralized `handleError` utility so SDK promise rejections are formatted consistently across identity and credential panels.

## Purpose / Motivation
Components previously inlined `e instanceof Error ? e.message : String(e)`, which produced inconsistent user-facing text and skipped structured handling for `SorobanIdentityError` codes. A single utility keeps logging, network detection, and display messages aligned.

## Changes Made
- Add `frontend/src/utils/handleError.ts` with `handleError()` and `isNetworkError()`
- Map `SorobanIdentityError` codes to friendly messages; preserve SDK messages for `NOT_FOUND` and `VALIDATION_ERROR`
- Log unexpected non-`Error` values to the console
- Update `IdentityPanel.tsx` and `CredentialsPanel.tsx` catch blocks to use the utility

## How to Test
1. Run `cd frontend && npm run build` — build should succeed.
2. Start the app (`npm run dev`), resolve a DID for an address with no on-chain identity — expect a clear not-found style message.
3. Disconnect network or use an invalid RPC URL, then resolve a DID — expect the network error banner with retry.
4. Connect Freighter and trigger a failed create/update — result area should show `Error: …` using the centralized formatter.
5. In Credentials, search by subject and issue a credential with invalid input — errors should use the same formatting pattern.

## Screenshots (if applicable)
N/A — messaging only; no layout changes.

## Breaking Changes
- None.

## Related Issues
Closes El-Chapo-Npm/Soroban-Identity#237

## Checklist
- [x] Code builds successfully
- [ ] Tests added/updated
- [x] No console errors (except intentional logging for unexpected errors)
- [ ] Documentation updated (if needed)