### PR TITLE
refactor: move Freighter wallet type declarations into a dedicated types file

### DIFF
--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -3,19 +3,6 @@ import SignClient from "@walletconnect/sign-client";
 import type { FrontendNetworkConfig } from "../network";
 import { getNetworkConfig, getActiveNetwork } from "../network";
 
-// ── Freighter types ───────────────────────────────────────────────────────────
-
-declare global {
-  interface Window {
-    freighter?: {
-      isConnected: () => Promise<boolean>;
-      getPublicKey: () => Promise<string>;
-      signTransaction: (xdr: string, opts?: { networkPassphrase?: string }) => Promise<string>;
-      getNetwork: () => Promise<{ network: string; networkPassphrase: string }>;
-    };
-  }
-}
-
 // ── Public types ──────────────────────────────────────────────────────────────
 
 export type WalletType = "freighter" | "walletconnect";

--- a/frontend/src/types/freighter.d.ts
+++ b/frontend/src/types/freighter.d.ts
@@ -1,0 +1,12 @@
+declare global {
+  interface Window {
+    freighter?: {
+      isConnected: () => Promise<boolean>;
+      getPublicKey: () => Promise<string>;
+      signTransaction: (xdr: string, opts?: { networkPassphrase?: string }) => Promise<string>;
+      getNetwork: () => Promise<{ network: string; networkPassphrase: string }>;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
Moves Freighter wallet `Window` type declarations out of `useWallet.ts` into a dedicated ambient types file so Freighter API usage is typed globally without cluttering the hook.

## Purpose / Motivation
`useWallet.ts` previously inlined a `declare global` block for `window.freighter`, mixing wallet hook logic with ambient type definitions. Centralizing those declarations improves maintainability, enables reuse across the frontend, and keeps TypeScript strict-mode checking for Freighter calls without implicit `any`.

## Changes Made
- Add `frontend/src/types/freighter.d.ts` with the Freighter `Window` extension (`isConnected`, `getPublicKey`, `signTransaction`, `getNetwork`)
- Remove the inline `declare global` block from `frontend/src/hooks/useWallet.ts`
- Preserve the existing Freighter API surface used by the hook (including `getNetwork` and `networkPassphrase` signing options)

## How to Test
1. From `frontend/`, run `npm run build` and confirm TypeScript completes with no errors under `strict: true`.
2. Start the app with `npm run dev` and connect via Freighter.
3. Confirm connect, account polling, and transaction signing still work.
4. In the IDE, type `window.freighter.` in any frontend file and verify autocomplete for Freighter methods.

## Breaking Changes
None.

## Related Issues
Closes El-Chapo-Npm/Soroban-Identity#235