### PR TITLE
refactor: consolidate issues #227 #228 #229 #230

### DIFF
--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -1,25 +1,28 @@
-import { createContext, useContext, ReactNode } from "react";
-import { WalletState } from "../hooks/useWallet";
+import { createContext, useContext, type ReactNode } from "react";
+import { useWallet } from "../hooks/useWallet";
+import type { WalletState } from "../hooks/useWalletState";
+import type { FrontendNetworkConfig } from "../network";
+import { getNetworkConfig } from "../network";
 
-interface WalletContextProps {
-  wallet: WalletState & {
-    connect: (walletType?: string) => void;
-    disconnect: () => void;
-    signTransaction: (xdr: string) => Promise<string>;
-  };
+interface WalletContextValue extends WalletState {
+  connect: (walletType?: string) => void;
+  disconnect: () => void;
+  signTransaction: (xdr: string) => Promise<string>;
 }
 
-const WalletContext = createContext<WalletContextProps | null>(null);
+const WalletContext = createContext<WalletContextValue | null>(null);
 
 export function WalletProvider({ children }: { children: ReactNode }) {
-  // Importing here to avoid circular dependency issues
-  const { useWallet } = require("../hooks/useWallet");
-  const wallet = useWallet();
-  return <WalletContext.Provider value={wallet}>{children}</WalletContext.Provider>;
+  const networkConfig: FrontendNetworkConfig = getNetworkConfig();
+  const wallet = useWallet(networkConfig);
+  return (
+    <WalletContext.Provider value={wallet}>{children}</WalletContext.Provider>
+  );
 }
 
-export function useWalletContext() {
+export function useWalletContext(): WalletContextValue {
   const ctx = useContext(WalletContext);
-  if (!ctx) throw new Error("useWalletContext must be used inside WalletProvider");
+  if (!ctx)
+    throw new Error("useWalletContext must be used inside WalletProvider");
   return ctx;
 }

--- a/frontend/src/hooks/useFreighterAccountSync.ts
+++ b/frontend/src/hooks/useFreighterAccountSync.ts
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import type { WalletState } from "./useWalletState";
+import { DISCONNECTED_STATE } from "./useWalletState";
+
+interface UseFreighterAccountSyncOptions {
+  state: WalletState;
+  setState: React.Dispatch<React.SetStateAction<WalletState>>;
+}
+
+/**
+ * Polls Freighter every 2 s while connected to detect mid-session account
+ * switches. Disconnects gracefully if Freighter becomes unavailable.
+ * Single responsibility: keep the stored public key in sync with Freighter.
+ */
+export function useFreighterAccountSync({
+  state,
+  setState,
+}: UseFreighterAccountSyncOptions) {
+  useEffect(() => {
+    if (state.walletType !== "freighter" || !state.connected) return;
+
+    const interval = setInterval(async () => {
+      if (!window.freighter) return;
+      try {
+        const currentKey = await window.freighter.getPublicKey();
+        if (currentKey !== state.publicKey) {
+          const { networkPassphrase } = await window.freighter.getNetwork();
+          setState({
+            publicKey: currentKey,
+            networkPassphrase,
+            connected: true,
+            connecting: false,
+            walletType: "freighter",
+            txLoading: false,
+            error: null,
+          });
+        }
+      } catch {
+        // Freighter became unavailable — disconnect gracefully
+        setState(DISCONNECTED_STATE);
+      }
+    }, 2000);
+
+    return () => clearInterval(interval);
+  }, [state.walletType, state.connected, state.publicKey, setState]);
+}

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -1,17 +1,24 @@
-import { useState, useCallback, useRef, useEffect } from "react";
-import SignClient from "@walletconnect/sign-client";
 import type { FrontendNetworkConfig } from "../network";
-import { getNetworkConfig, getActiveNetwork } from "../network";
+import { useWalletState } from "./useWalletState";
+import { useWalletConnection } from "./useWalletConnection";
+import { useWalletSigning } from "./useWalletSigning";
+import { useFreighterAccountSync } from "./useFreighterAccountSync";
 
-// ── Freighter types ───────────────────────────────────────────────────────────
+// ── Freighter global types ────────────────────────────────────────────────────
 
 declare global {
   interface Window {
     freighter?: {
       isConnected: () => Promise<boolean>;
       getPublicKey: () => Promise<string>;
-      signTransaction: (xdr: string, opts?: { networkPassphrase?: string }) => Promise<string>;
-      getNetwork: () => Promise<{ network: string; networkPassphrase: string }>;
+      signTransaction: (
+        xdr: string,
+        opts?: { networkPassphrase?: string }
+      ) => Promise<string>;
+      getNetwork: () => Promise<{
+        network: string;
+        networkPassphrase: string;
+      }>;
     };
   }
 }
@@ -20,305 +27,35 @@ declare global {
 
 export type WalletType = "freighter" | "walletconnect";
 
-export interface WalletState {
-  publicKey: string | null;
-  networkPassphrase: string | null;
-  connected: boolean;
-  connecting: boolean;
-  txLoading: boolean;
-  walletType: WalletType | null;
-  error: string | null;
-}
+export type { WalletState } from "./useWalletState";
 
-// WalletConnect project ID — replace with your own from https://cloud.walletconnect.com
-const WC_PROJECT_ID = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID ?? "YOUR_PROJECT_ID";
+// ── Composed hook ─────────────────────────────────────────────────────────────
 
-// ── Hook ──────────────────────────────────────────────────────────────────────
-
+/**
+ * Composes the focused wallet hooks into a single public API.
+ *
+ * - {@link useWalletState}            — raw state atom
+ * - {@link useWalletConnection}       — connect / disconnect / auto-reconnect
+ * - {@link useFreighterAccountSync}   — mid-session account-switch detection
+ * - {@link useWalletSigning}          — XDR signing
+ */
 export function useWallet(networkConfig: FrontendNetworkConfig) {
-  const [state, setState] = useState<WalletState>({
-    publicKey: null,
-    networkPassphrase: null,
-    connected: false,
-    connecting: false,
-    txLoading: false,
-    walletType: null,
-    error: null,
+  const { state, setState } = useWalletState();
+
+  const { connect, disconnect: _disconnect, wcClientRef, wcTopicRef } =
+    useWalletConnection({ networkConfig, setState });
+
+  useFreighterAccountSync({ state, setState });
+
+  const { signTransaction } = useWalletSigning({
+    networkConfig,
+    state,
+    setState,
+    wcClientRef,
+    wcTopicRef,
   });
 
-  // Hold WalletConnect session ref so signTransaction can access it
-  const wcClientRef = useRef<Awaited<ReturnType<typeof SignClient.init>> | null>(null);
-  const wcTopicRef = useRef<string | null>(null);
-
-  // ── Freighter ───────────────────────────────────────────────────────────────
-
-  const connectFreighter = useCallback(async () => {
-    if (!window.freighter) {
-      setState((s) => ({
-        ...s,
-        connecting: false,
-        error: "Freighter not found. Install it from freighter.app",
-      }));
-      return;
-    }
-
-    try {
-      const isConnected = await window.freighter.isConnected();
-      if (!isConnected) {
-        setState((s) => ({
-          ...s,
-          connecting: false,
-          error: "Please unlock Freighter and try again.",
-        }));
-        return;
-      }
-
-      const [publicKey, { networkPassphrase }] = await Promise.all([
-        window.freighter.getPublicKey(),
-        window.freighter.getNetwork(),
-      ]);
-
-      const activeNetworkConfig = getNetworkConfig();
-      if (networkPassphrase !== activeNetworkConfig.networkPassphrase) {
-        setState((s) => ({
-          ...s,
-          connecting: false,
-          error: `Freighter is on the wrong network. Expected ${getActiveNetwork()}.`,
-        }));
-        return;
-      }
-
-      localStorage.setItem("soroban-wallet-connected", "freighter");
-
-      setState({
-        publicKey,
-        networkPassphrase,
-        connected: true,
-        connecting: false,
-        txLoading: false,
-        walletType: "freighter",
-        error: null,
-      });
-    } catch (e: unknown) {
-      setState((s) => ({
-        ...s,
-        connecting: false,
-        error: e instanceof Error ? e.message : "Freighter connection failed",
-      }));
-    }
-  }, []);
-
-  // ── Freighter account-change detection ─────────────────────────────────────
-  // Poll Freighter every 2 s while connected to detect mid-session account switches.
-
-  useEffect(() => {
-    if (state.walletType !== "freighter" || !state.connected) return;
-
-    const interval = setInterval(async () => {
-      if (!window.freighter) return;
-      try {
-        const currentKey = await window.freighter.getPublicKey();
-        if (currentKey !== state.publicKey) {
-          // Account switched — update state and clear cached data
-          const { networkPassphrase } = await window.freighter.getNetwork();
-          setState({
-            publicKey: currentKey,
-            networkPassphrase,
-            connected: true,
-            connecting: false,
-            walletType: "freighter",
-            txLoading: false,
-            error: null,
-          });
-        }
-      } catch {
-        // Freighter became unavailable — disconnect gracefully
-        setState({
-          publicKey: null,
-          networkPassphrase: null,
-          connected: false,
-          connecting: false,
-          walletType: null,
-          txLoading: false,
-          error: null,
-        });
-      }
-    }, 2000);
-
-    return () => clearInterval(interval);
-  }, [state.walletType, state.connected, state.publicKey]);
-
-  // ── WalletConnect ───────────────────────────────────────────────────────────
-
-  const connectWalletConnect = useCallback(async () => {
-    try {
-      const client = await SignClient.init({
-        projectId: WC_PROJECT_ID,
-        metadata: {
-          name: "Soroban Identity",
-          description: "Decentralized Identity for a Trustless World",
-          url: window.location.origin,
-          icons: [`${window.location.origin}/favicon.ico`],
-        },
-      });
-
-      wcClientRef.current = client;
-
-      const { uri, approval } = await client.connect({
-        requiredNamespaces: {
-          stellar: {
-            methods: ["stellar_signXDR"],
-            chains: [networkConfig.walletConnectChain],
-            events: ["accountsChanged"],
-          },
-        },
-      });
-
-      // Open QR modal — in production use @walletconnect/modal
-      if (uri) {
-        window.open(
-          `https://walletconnect.com/wc?uri=${encodeURIComponent(uri)}`,
-          "_blank"
-        );
-      }
-
-      const session = await approval();
-      wcTopicRef.current = session.topic;
-
-      // Extract Stellar public key from namespace accounts (format: "stellar:<network>:GXXX...")
-      const accounts = session.namespaces.stellar?.accounts ?? [];
-      const publicKey = accounts[0]?.split(":")[2] ?? null;
-
-      localStorage.setItem("soroban-wallet-connected", "walletconnect");
-
-      setState({
-        publicKey,
-        networkPassphrase: networkConfig.networkPassphrase,
-        connected: true,
-        connecting: false,
-        txLoading: false,
-        walletType: "walletconnect",
-        error: null,
-      });
-
-      // Handle remote disconnect
-      client.on("session_delete", () => {
-        wcTopicRef.current = null;
-        localStorage.removeItem("soroban-wallet-connected");
-        setState({
-          publicKey: null,
-          networkPassphrase: null,
-          connected: false,
-          connecting: false,
-          txLoading: false,
-          walletType: null,
-          error: null,
-        });
-      });
-    } catch (e: unknown) {
-      setState((s) => ({
-        ...s,
-        connecting: false,
-        error: e instanceof Error ? e.message : "WalletConnect connection failed",
-      }));
-    }
-  }, [networkConfig.networkPassphrase, networkConfig.walletConnectChain]);
-
-  // ── Auto-reconnect on mount ─────────────────────────────────────────────────
-  
-  useEffect(() => {
-    const saved = localStorage.getItem("soroban-wallet-connected");
-    if (saved === "freighter") {
-      connectFreighter();
-    } else if (saved === "walletconnect") {
-      connectWalletConnect();
-    }
-  }, [connectFreighter, connectWalletConnect]);
-
-  // ── Public API ──────────────────────────────────────────────────────────────
-
-  const connect = useCallback(
-    async (walletType: WalletType = "freighter") => {
-      setState((s) => ({ ...s, connecting: true, error: null }));
-      if (walletType === "walletconnect") {
-        await connectWalletConnect();
-      } else {
-        await connectFreighter();
-      }
-    },
-    [connectFreighter, connectWalletConnect]
-  );
-
-  const disconnect = useCallback(async () => {
-    if (state.walletType === "walletconnect" && wcClientRef.current && wcTopicRef.current) {
-      try {
-        await wcClientRef.current.disconnect({
-          topic: wcTopicRef.current,
-          reason: { code: 6000, message: "User disconnected" },
-        });
-      } catch {
-        // ignore — session may already be gone
-      }
-      wcClientRef.current = null;
-      wcTopicRef.current = null;
-    }
-
-    localStorage.removeItem("soroban-wallet-connected");
-
-    setState({
-      publicKey: null,
-      networkPassphrase: null,
-      connected: false,
-      connecting: false,
-      txLoading: false,
-      walletType: null,
-      error: null,
-    });
-  }, [state.walletType]);
-
-  /**
-   * Sign a transaction XDR string using whichever wallet is active.
-   * Returns the signed XDR.
-   */
-  const signTransaction = useCallback(
-    async (xdr: string): Promise<string> => {
-      if (!state.connected) throw new Error("Wallet not connected");
-
-      setState((s) => ({ ...s, txLoading: true }));
-      try {
-        if (state.walletType === "walletconnect") {
-          if (!wcClientRef.current || !wcTopicRef.current) {
-            throw new Error("WalletConnect session not available");
-          }
-          const result = await wcClientRef.current.request<{ signedXDR: string }>({
-            topic: wcTopicRef.current,
-            chainId: networkConfig.walletConnectChain,
-            request: {
-              method: "stellar_signXDR",
-              params: { xdr },
-            },
-          });
-          return result.signedXDR;
-        }
-
-        // Freighter
-        if (!window.freighter || !state.networkPassphrase) {
-          throw new Error("Freighter not available");
-        }
-        return await window.freighter.signTransaction(xdr, {
-          networkPassphrase: state.networkPassphrase,
-        });
-      } finally {
-        setState((s) => ({ ...s, txLoading: false }));
-      }
-    },
-    [
-      networkConfig.walletConnectChain,
-      state.connected,
-      state.walletType,
-      state.networkPassphrase,
-    ]
-  );
+  const disconnect = () => _disconnect(state.walletType);
 
   return { ...state, connect, disconnect, signTransaction };
 }

--- a/frontend/src/hooks/useWalletConnection.ts
+++ b/frontend/src/hooks/useWalletConnection.ts
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useRef } from "react";
+import SignClient from "@walletconnect/sign-client";
+import type { FrontendNetworkConfig } from "../network";
+import { getNetworkConfig, getActiveNetwork } from "../network";
+import type { WalletState } from "./useWalletState";
+import { DISCONNECTED_STATE } from "./useWalletState";
+import type { WalletType } from "./useWallet";
+
+const WC_PROJECT_ID =
+  import.meta.env.VITE_WALLETCONNECT_PROJECT_ID ?? "YOUR_PROJECT_ID";
+
+interface UseWalletConnectionOptions {
+  networkConfig: FrontendNetworkConfig;
+  setState: React.Dispatch<React.SetStateAction<WalletState>>;
+}
+
+/**
+ * Handles wallet connection and disconnection for both Freighter and
+ * WalletConnect. Single responsibility: establish / tear down sessions.
+ *
+ * Returns `connect`, `disconnect`, and the WalletConnect refs so the signing
+ * hook can access the live session.
+ */
+export function useWalletConnection({
+  networkConfig,
+  setState,
+}: UseWalletConnectionOptions) {
+  const wcClientRef =
+    useRef<Awaited<ReturnType<typeof SignClient.init>> | null>(null);
+  const wcTopicRef = useRef<string | null>(null);
+
+  // ── Freighter ─────────────────────────────────────────────────────────────
+
+  const connectFreighter = useCallback(async () => {
+    if (!window.freighter) {
+      setState((s) => ({
+        ...s,
+        connecting: false,
+        error: "Freighter not found. Install it from freighter.app",
+      }));
+      return;
+    }
+
+    try {
+      const isConnected = await window.freighter.isConnected();
+      if (!isConnected) {
+        setState((s) => ({
+          ...s,
+          connecting: false,
+          error: "Please unlock Freighter and try again.",
+        }));
+        return;
+      }
+
+      const [publicKey, { networkPassphrase }] = await Promise.all([
+        window.freighter.getPublicKey(),
+        window.freighter.getNetwork(),
+      ]);
+
+      const activeNetworkConfig = getNetworkConfig();
+      if (networkPassphrase !== activeNetworkConfig.networkPassphrase) {
+        setState((s) => ({
+          ...s,
+          connecting: false,
+          error: `Freighter is on the wrong network. Expected ${getActiveNetwork()}.`,
+        }));
+        return;
+      }
+
+      localStorage.setItem("soroban-wallet-connected", "freighter");
+
+      setState({
+        publicKey,
+        networkPassphrase,
+        connected: true,
+        connecting: false,
+        txLoading: false,
+        walletType: "freighter",
+        error: null,
+      });
+    } catch (e: unknown) {
+      setState((s) => ({
+        ...s,
+        connecting: false,
+        error: e instanceof Error ? e.message : "Freighter connection failed",
+      }));
+    }
+  }, [setState]);
+
+  // ── WalletConnect ──────────────────────────────────────────────────────────
+
+  const connectWalletConnect = useCallback(async () => {
+    try {
+      const client = await SignClient.init({
+        projectId: WC_PROJECT_ID,
+        metadata: {
+          name: "Soroban Identity",
+          description: "Decentralized Identity for a Trustless World",
+          url: window.location.origin,
+          icons: [`${window.location.origin}/favicon.ico`],
+        },
+      });
+
+      wcClientRef.current = client;
+
+      const { uri, approval } = await client.connect({
+        requiredNamespaces: {
+          stellar: {
+            methods: ["stellar_signXDR"],
+            chains: [networkConfig.walletConnectChain],
+            events: ["accountsChanged"],
+          },
+        },
+      });
+
+      if (uri) {
+        window.open(
+          `https://walletconnect.com/wc?uri=${encodeURIComponent(uri)}`,
+          "_blank"
+        );
+      }
+
+      const session = await approval();
+      wcTopicRef.current = session.topic;
+
+      const accounts = session.namespaces.stellar?.accounts ?? [];
+      const publicKey = accounts[0]?.split(":")[2] ?? null;
+
+      localStorage.setItem("soroban-wallet-connected", "walletconnect");
+
+      setState({
+        publicKey,
+        networkPassphrase: networkConfig.networkPassphrase,
+        connected: true,
+        connecting: false,
+        txLoading: false,
+        walletType: "walletconnect",
+        error: null,
+      });
+
+      client.on("session_delete", () => {
+        wcTopicRef.current = null;
+        localStorage.removeItem("soroban-wallet-connected");
+        setState(DISCONNECTED_STATE);
+      });
+    } catch (e: unknown) {
+      setState((s) => ({
+        ...s,
+        connecting: false,
+        error:
+          e instanceof Error ? e.message : "WalletConnect connection failed",
+      }));
+    }
+  }, [networkConfig.networkPassphrase, networkConfig.walletConnectChain, setState]);
+
+  // ── Auto-reconnect on mount ────────────────────────────────────────────────
+
+  useEffect(() => {
+    const saved = localStorage.getItem("soroban-wallet-connected");
+    if (saved === "freighter") {
+      connectFreighter();
+    } else if (saved === "walletconnect") {
+      connectWalletConnect();
+    }
+  }, [connectFreighter, connectWalletConnect]);
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  const connect = useCallback(
+    async (walletType: WalletType = "freighter") => {
+      setState((s) => ({ ...s, connecting: true, error: null }));
+      if (walletType === "walletconnect") {
+        await connectWalletConnect();
+      } else {
+        await connectFreighter();
+      }
+    },
+    [connectFreighter, connectWalletConnect, setState]
+  );
+
+  const disconnect = useCallback(
+    async (currentWalletType: WalletType | null) => {
+      if (
+        currentWalletType === "walletconnect" &&
+        wcClientRef.current &&
+        wcTopicRef.current
+      ) {
+        try {
+          await wcClientRef.current.disconnect({
+            topic: wcTopicRef.current,
+            reason: { code: 6000, message: "User disconnected" },
+          });
+        } catch {
+          // ignore — session may already be gone
+        }
+        wcClientRef.current = null;
+        wcTopicRef.current = null;
+      }
+
+      localStorage.removeItem("soroban-wallet-connected");
+      setState(DISCONNECTED_STATE);
+    },
+    [setState]
+  );
+
+  return { connect, disconnect, wcClientRef, wcTopicRef };
+}

--- a/frontend/src/hooks/useWalletSigning.ts
+++ b/frontend/src/hooks/useWalletSigning.ts
@@ -1,0 +1,73 @@
+import { useCallback } from "react";
+import SignClient from "@walletconnect/sign-client";
+import type { FrontendNetworkConfig } from "../network";
+import type { WalletState } from "./useWalletState";
+
+interface UseWalletSigningOptions {
+  networkConfig: FrontendNetworkConfig;
+  state: WalletState;
+  setState: React.Dispatch<React.SetStateAction<WalletState>>;
+  wcClientRef: React.MutableRefObject<Awaited<
+    ReturnType<typeof SignClient.init>
+  > | null>;
+  wcTopicRef: React.MutableRefObject<string | null>;
+}
+
+/**
+ * Handles transaction signing for whichever wallet is currently active.
+ * Single responsibility: sign an XDR string and return the signed XDR.
+ */
+export function useWalletSigning({
+  networkConfig,
+  state,
+  setState,
+  wcClientRef,
+  wcTopicRef,
+}: UseWalletSigningOptions) {
+  const signTransaction = useCallback(
+    async (xdr: string): Promise<string> => {
+      if (!state.connected) throw new Error("Wallet not connected");
+
+      setState((s) => ({ ...s, txLoading: true }));
+      try {
+        if (state.walletType === "walletconnect") {
+          if (!wcClientRef.current || !wcTopicRef.current) {
+            throw new Error("WalletConnect session not available");
+          }
+          const result = await wcClientRef.current.request<{
+            signedXDR: string;
+          }>({
+            topic: wcTopicRef.current,
+            chainId: networkConfig.walletConnectChain,
+            request: {
+              method: "stellar_signXDR",
+              params: { xdr },
+            },
+          });
+          return result.signedXDR;
+        }
+
+        // Freighter
+        if (!window.freighter || !state.networkPassphrase) {
+          throw new Error("Freighter not available");
+        }
+        return await window.freighter.signTransaction(xdr, {
+          networkPassphrase: state.networkPassphrase,
+        });
+      } finally {
+        setState((s) => ({ ...s, txLoading: false }));
+      }
+    },
+    [
+      networkConfig.walletConnectChain,
+      state.connected,
+      state.walletType,
+      state.networkPassphrase,
+      setState,
+      wcClientRef,
+      wcTopicRef,
+    ]
+  );
+
+  return { signTransaction };
+}

--- a/frontend/src/hooks/useWalletState.ts
+++ b/frontend/src/hooks/useWalletState.ts
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import type { WalletType } from "./useWallet";
+
+export interface WalletState {
+  publicKey: string | null;
+  networkPassphrase: string | null;
+  connected: boolean;
+  connecting: boolean;
+  txLoading: boolean;
+  walletType: WalletType | null;
+  error: string | null;
+}
+
+export const DISCONNECTED_STATE: WalletState = {
+  publicKey: null,
+  networkPassphrase: null,
+  connected: false,
+  connecting: false,
+  txLoading: false,
+  walletType: null,
+  error: null,
+};
+
+/**
+ * Manages the raw wallet state atom.
+ * Separated so connection and signing hooks can share a single state setter
+ * without duplicating the shape definition.
+ */
+export function useWalletState() {
+  const [state, setState] = useState<WalletState>(DISCONNECTED_STATE);
+  return { state, setState };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -44,6 +44,8 @@
   --sybil-fail-border:        #dc2626;
   --filter-badge-active-bg:   #7c3aed;
   --filter-badge-active-text: #ffffff;
+  --btn-text:                 #ffffff;
+  --focus-ring:               #7c3aed;
 }
 
 /* ── Dark mode via system preference ─────────────────────────────────────────── */
@@ -91,6 +93,8 @@
     --sybil-fail-border:        #f87171;
     --filter-badge-active-bg:   #a78bfa;
     --filter-badge-active-text: #1e1b4b;
+    --btn-text:                 #ffffff;
+    --focus-ring:               #a78bfa;
   }
 }
 
@@ -138,6 +142,8 @@ html.dark {
   --sybil-fail-border:        #f87171;
   --filter-badge-active-bg:   #a78bfa;
   --filter-badge-active-text: #1e1b4b;
+  --btn-text:                 #ffffff;
+  --focus-ring:               #a78bfa;
 }
 
 /* ── Light mode forced via manual class toggle ───────────────────────────────── */
@@ -184,6 +190,8 @@ html.light {
   --sybil-fail-border:        #dc2626;
   --filter-badge-active-bg:   #7c3aed;
   --filter-badge-active-text: #ffffff;
+  --btn-text:                 #ffffff;
+  --focus-ring:               #7c3aed;
 }
 
 /* ── Base styles ─────────────────────────────────────────────────────────────── */
@@ -240,7 +248,7 @@ select {
 
 button {
   background: var(--accent);
-  color: #fff;
+  color: var(--btn-text);
   border: none;
   border-radius: 8px;
   padding: 0.6rem 1.2rem;
@@ -284,7 +292,7 @@ button:disabled { background: var(--btn-disabled-bg); color: var(--btn-disabled-
   padding: 0.5rem 1rem;
   border-radius: 8px;
 }
-.tab.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+.tab.active { background: var(--accent); border-color: var(--accent); color: var(--btn-text); }
 
 /* ── Spinner ─────────────────────────────────────────────────────────────────── */
 
@@ -466,14 +474,14 @@ button:disabled { background: var(--btn-disabled-bg); color: var(--btn-disabled-
    Visible focus indicator for all interactive elements.
    Uses :focus-visible so mouse users don't see the ring. */
 :focus-visible {
-  outline: 2px solid var(--accent-light, #7c6af7);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
   border-radius: 4px;
 }
 
 /* Credential cards are divs with role="button" — same ring treatment */
 [role="button"]:focus-visible {
-  outline: 2px solid var(--accent-light, #7c6af7);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
   border-radius: 0.5rem;
 }

--- a/sdk/src/contract-args.ts
+++ b/sdk/src/contract-args.ts
@@ -1,0 +1,207 @@
+/**
+ * Named argument builders for each contract call in the SDK.
+ *
+ * Instead of building positional `ScVal` arrays inline, every contract method
+ * has a dedicated builder function whose parameters are named and typed. This
+ * means a parameter reorder in the contract is caught at the call-site (wrong
+ * name → TypeScript error) rather than silently producing a bad transaction.
+ *
+ * Each function returns `xdr.ScVal[]` ready to spread into `contract.call()`.
+ */
+
+import { nativeToScVal, xdr } from '@stellar/stellar-sdk';
+import type { CredentialType } from './types';
+
+// ── identity-registry ────────────────────────────────────────────────────────
+
+export function buildCreateDidArgs(params: {
+  controller: string;
+  metadata: Record<string, string>;
+}): xdr.ScVal[] {
+  return [
+    nativeToScVal(params.controller, { type: 'address' }),
+    nativeToScVal(params.metadata, { type: 'map' }),
+  ];
+}
+
+export function buildUpdateDidArgs(params: {
+  controller: string;
+  metadata: Record<string, string>;
+}): xdr.ScVal[] {
+  return [
+    nativeToScVal(params.controller, { type: 'address' }),
+    nativeToScVal(params.metadata, { type: 'map' }),
+  ];
+}
+
+export function buildResolveDidArgs(params: {
+  controller: string;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.controller, { type: 'address' })];
+}
+
+export function buildHasActiveDidArgs(params: {
+  controller: string;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.controller, { type: 'address' })];
+}
+
+export function buildDeactivateDidArgs(params: {
+  controller: string;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.controller, { type: 'address' })];
+}
+
+// ── credential-manager ───────────────────────────────────────────────────────
+
+export function buildIssueCredentialArgs(params: {
+  issuer: string;
+  subject: string;
+  credentialType: CredentialType;
+  claims: Record<string, string>;
+  claimsHash: Buffer;
+  signature: Buffer;
+  expiresAt: number;
+}): xdr.ScVal[] {
+  return [
+    nativeToScVal(params.issuer, { type: 'address' }),
+    nativeToScVal(params.subject, { type: 'address' }),
+    nativeToScVal(params.credentialType, { type: 'symbol' }),
+    nativeToScVal(params.claims, { type: 'map' }),
+    nativeToScVal(params.claimsHash, { type: 'bytes' }),
+    nativeToScVal(params.signature, { type: 'bytes' }),
+    nativeToScVal(params.expiresAt, { type: 'u64' }),
+  ];
+}
+
+export function buildVerifyCredentialArgs(params: {
+  credentialId: Buffer;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.credentialId, { type: 'bytes' })];
+}
+
+export function buildGetCredentialArgs(params: {
+  credentialId: Buffer;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.credentialId, { type: 'bytes' })];
+}
+
+export function buildGetSubjectCredentialsArgs(params: {
+  subject: string;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.subject, { type: 'address' })];
+}
+
+export function buildIsIssuerArgs(params: {
+  address: string;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.address, { type: 'address' })];
+}
+
+export function buildGetCredentialCountArgs(params: {
+  subject: string;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.subject, { type: 'address' })];
+}
+
+export function buildListSubjectCredentialsArgs(params: {
+  subject: string;
+  cursor: xdr.ScVal;
+  limit: number;
+  filter: xdr.ScVal;
+}): xdr.ScVal[] {
+  return [
+    nativeToScVal(params.subject, { type: 'address' }),
+    params.cursor,
+    nativeToScVal(params.limit, { type: 'u32' }),
+    params.filter,
+  ];
+}
+
+export function buildListIssuersArgs(params: {
+  cursor: xdr.ScVal;
+  limit: number;
+}): xdr.ScVal[] {
+  return [
+    params.cursor,
+    nativeToScVal(params.limit, { type: 'u32' }),
+  ];
+}
+
+// ── reputation ───────────────────────────────────────────────────────────────
+
+export function buildGetReputationArgs(params: {
+  subject: string;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.subject, { type: 'address' })];
+}
+
+export function buildGetHistoryArgs(params: {
+  subject: string;
+  reporter: string;
+  offset: number;
+  limit: number;
+}): xdr.ScVal[] {
+  return [
+    nativeToScVal(params.subject, { type: 'address' }),
+    nativeToScVal(params.reporter, { type: 'address' }),
+    nativeToScVal(params.offset, { type: 'u32' }),
+    nativeToScVal(params.limit, { type: 'u32' }),
+  ];
+}
+
+export function buildPassesSybilCheckDefaultArgs(params: {
+  subject: string;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.subject, { type: 'address' })];
+}
+
+export function buildPassesSybilCheckArgs(params: {
+  subject: string;
+  minScore: number;
+  minReporters: number;
+}): xdr.ScVal[] {
+  return [
+    nativeToScVal(params.subject, { type: 'address' }),
+    nativeToScVal(params.minScore, { type: 'i64' }),
+    nativeToScVal(params.minReporters, { type: 'u32' }),
+  ];
+}
+
+export function buildSubmitScoreArgs(params: {
+  reporter: string;
+  subject: string;
+  delta: number;
+  reason: string;
+}): xdr.ScVal[] {
+  return [
+    nativeToScVal(params.reporter, { type: 'address' }),
+    nativeToScVal(params.subject, { type: 'address' }),
+    nativeToScVal(params.delta, { type: 'i64' }),
+    nativeToScVal(params.reason, { type: 'string' }),
+  ];
+}
+
+export function buildListReportersArgs(params: {
+  cursor: xdr.ScVal;
+  limit: number;
+}): xdr.ScVal[] {
+  return [
+    params.cursor,
+    nativeToScVal(params.limit, { type: 'u32' }),
+  ];
+}
+
+export function buildListHistoryArgs(params: {
+  subject: string;
+  reporter: string;
+  cursor: xdr.ScVal;
+  limit: number;
+}): xdr.ScVal[] {
+  return [
+    nativeToScVal(params.subject, { type: 'address' }),
+    nativeToScVal(params.reporter, { type: 'address' }),
+    params.cursor,
+    nativeToScVal(params.limit, { type: 'u32' }),
+  ];
+}

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -23,6 +23,16 @@ import { retryWithBackoff, validateStellarAddress, pollTransactionStatus } from 
 import { ContractError, SorobanIdentityError } from "./errors";
 import { CREDENTIAL_MANAGER_ERRORS } from "./error-codes";
 import { BaseClient } from "./base-client";
+import {
+  buildIssueCredentialArgs,
+  buildVerifyCredentialArgs,
+  buildGetCredentialArgs,
+  buildGetSubjectCredentialsArgs,
+  buildIsIssuerArgs,
+  buildGetCredentialCountArgs,
+  buildListSubjectCredentialsArgs,
+  buildListIssuersArgs,
+} from "./contract-args";
 
 const PROBE_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
 const CREDENTIAL_VERIFY_NOT_FOUND_CODE = 2;
@@ -67,7 +77,7 @@ export class CredentialClient extends BaseClient {
         .addOperation(
           this.contract.call(
             "is_issuer",
-            nativeToScVal(PROBE_ADDRESS, { type: "address" })
+            ...buildIsIssuerArgs({ address: PROBE_ADDRESS })
           )
         )
         .setTimeout(10)
@@ -156,13 +166,15 @@ export class CredentialClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "issue_credential",
-          nativeToScVal(issuerKeypair.publicKey(), { type: "address" }),
-          nativeToScVal(subjectAddress, { type: "address" }),
-          nativeToScVal(credentialType, { type: "symbol" }),
-          nativeToScVal(claims, { type: "map" }),
-          nativeToScVal(Buffer.from(claimsHashHex, "hex"), { type: "bytes" }),
-          nativeToScVal(signature, { type: "bytes" }),
-          nativeToScVal(expiresAt, { type: "u64" })
+          ...buildIssueCredentialArgs({
+            issuer: issuerKeypair.publicKey(),
+            subject: subjectAddress,
+            credentialType,
+            claims,
+            claimsHash: Buffer.from(claimsHashHex, "hex"),
+            signature: Buffer.from(signature),
+            expiresAt,
+          })
         )
       )
       .setTimeout(timeout)
@@ -223,7 +235,7 @@ export class CredentialClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "verify_credential",
-          nativeToScVal(idBytes, { type: "bytes" })
+          ...buildVerifyCredentialArgs({ credentialId: idBytes })
         )
       )
       .setTimeout(timeout)
@@ -302,7 +314,7 @@ export class CredentialClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "get_subject_credentials",
-          nativeToScVal(subjectAddress, { type: "address" })
+          ...buildGetSubjectCredentialsArgs({ subject: subjectAddress })
         )
       )
       .setTimeout(timeout)
@@ -364,7 +376,7 @@ export class CredentialClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "get_credential",
-          nativeToScVal(idBytes, { type: "bytes" })
+          ...buildGetCredentialArgs({ credentialId: idBytes })
         )
       )
       .setTimeout(timeout)
@@ -420,7 +432,7 @@ export class CredentialClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "is_issuer",
-          nativeToScVal(targetAddress, { type: "address" })
+          ...buildIsIssuerArgs({ address: targetAddress })
         )
       )
       .setTimeout(timeout)
@@ -497,7 +509,7 @@ export class CredentialClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "get_credential_count",
-          nativeToScVal(subjectAddress, { type: "address" })
+          ...buildGetCredentialCountArgs({ subject: subjectAddress })
         )
       )
       .setTimeout(timeout)
@@ -662,10 +674,12 @@ export class CredentialClient extends BaseClient {
       .addOperation(
         this.contract.call(
           'list_subject_credentials',
-          nativeToScVal(subjectAddress, { type: 'address' }),
-          cursorArg,
-          nativeToScVal(options?.limit ?? 0, { type: 'u32' }),
-          filterArg
+          ...buildListSubjectCredentialsArgs({
+            subject: subjectAddress,
+            cursor: cursorArg,
+            limit: options?.limit ?? 0,
+            filter: filterArg,
+          })
         )
       )
       .setTimeout(timeout)
@@ -719,8 +733,10 @@ export class CredentialClient extends BaseClient {
       .addOperation(
         this.contract.call(
           'list_issuers',
-          cursorArg,
-          nativeToScVal(options?.limit ?? 0, { type: 'u32' })
+          ...buildListIssuersArgs({
+            cursor: cursorArg,
+            limit: options?.limit ?? 0,
+          })
         )
       )
       .setTimeout(timeout)

--- a/sdk/src/identity.ts
+++ b/sdk/src/identity.ts
@@ -4,7 +4,6 @@ import {
   TransactionBuilder,
   BASE_FEE,
   Keypair,
-  nativeToScVal,
   scValToNative,
   Account,
 } from "@stellar/stellar-sdk";
@@ -13,6 +12,13 @@ import { retryWithBackoff, validateStellarAddress, pollTransactionStatus } from 
 import { ContractError, SorobanIdentityError } from "./errors";
 import { IDENTITY_REGISTRY_ERRORS } from "./error-codes";
 import { BaseClient } from "./base-client";
+import {
+  buildCreateDidArgs,
+  buildUpdateDidArgs,
+  buildResolveDidArgs,
+  buildHasActiveDidArgs,
+  buildDeactivateDidArgs,
+} from "./contract-args";
 
 // Dummy address used for lightweight initialization probes
 const PROBE_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
@@ -54,7 +60,7 @@ export class IdentityClient extends BaseClient {
         .addOperation(
           this.contract.call(
             "has_active_did",
-            nativeToScVal(PROBE_ADDRESS, { type: "address" })
+            ...buildHasActiveDidArgs({ controller: PROBE_ADDRESS })
           )
         )
         .setTimeout(10)
@@ -102,7 +108,6 @@ export class IdentityClient extends BaseClient {
   ): Promise<{ did: string } & WriteResult> {
     const account = await this.server.getAccount(keypair.publicKey());
 
-    const metaScVal = nativeToScVal(metadata, { type: "map" });
     const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
     const tx = new TransactionBuilder(account, {
@@ -112,8 +117,7 @@ export class IdentityClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "create_did",
-          nativeToScVal(keypair.publicKey(), { type: "address" }),
-          metaScVal
+          ...buildCreateDidArgs({ controller: keypair.publicKey(), metadata })
         )
       )
       .setTimeout(timeout)
@@ -180,8 +184,7 @@ export class IdentityClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "update_did",
-          nativeToScVal(keypair.publicKey(), { type: "address" }),
-          nativeToScVal(metadata, { type: "map" })
+          ...buildUpdateDidArgs({ controller: keypair.publicKey(), metadata })
         )
       )
       .setTimeout(timeout)
@@ -243,7 +246,7 @@ export class IdentityClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "resolve_did",
-          nativeToScVal(controllerAddress, { type: "address" })
+          ...buildResolveDidArgs({ controller: controllerAddress })
         )
       )
       .setTimeout(timeout)
@@ -291,7 +294,7 @@ export class IdentityClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "has_active_did",
-          nativeToScVal(controllerAddress, { type: "address" })
+          ...buildHasActiveDidArgs({ controller: controllerAddress })
         )
       )
       .setTimeout(timeout)
@@ -379,7 +382,7 @@ export class IdentityClient extends BaseClient {
       .addOperation(
         this.contract.call(
           "deactivate_did",
-          nativeToScVal(keypair.publicKey(), { type: "address" })
+          ...buildDeactivateDidArgs({ controller: keypair.publicKey() })
         )
       )
       .setTimeout(this.config.txTimeout ?? 30)

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -18,6 +18,28 @@ export {
 } from './error-codes';
 export { clearServerCache } from './base-client';
 export { toW3CDidDocument, exportDidDocumentAsJsonLd } from './serializers';
+export {
+  buildCreateDidArgs,
+  buildUpdateDidArgs,
+  buildResolveDidArgs,
+  buildHasActiveDidArgs,
+  buildDeactivateDidArgs,
+  buildIssueCredentialArgs,
+  buildVerifyCredentialArgs,
+  buildGetCredentialArgs,
+  buildGetSubjectCredentialsArgs,
+  buildIsIssuerArgs,
+  buildGetCredentialCountArgs,
+  buildListSubjectCredentialsArgs,
+  buildListIssuersArgs,
+  buildGetReputationArgs,
+  buildGetHistoryArgs,
+  buildPassesSybilCheckDefaultArgs,
+  buildPassesSybilCheckArgs,
+  buildSubmitScoreArgs,
+  buildListReportersArgs,
+  buildListHistoryArgs,
+} from './contract-args';
 export type {
   DidDocument,
   Credential,

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -24,6 +24,15 @@ import { SorobanTransactionBuilder } from './transaction-builder';
 import { ContractError, SorobanIdentityError } from "./errors";
 import { REPUTATION_ERRORS } from './error-codes';
 import { BaseClient } from './base-client';
+import {
+  buildGetReputationArgs,
+  buildGetHistoryArgs,
+  buildPassesSybilCheckDefaultArgs,
+  buildPassesSybilCheckArgs,
+  buildSubmitScoreArgs,
+  buildListReportersArgs,
+  buildListHistoryArgs,
+} from './contract-args';
 
 const PROBE_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
 
@@ -58,14 +67,9 @@ export interface ScoreHistoryEntry {
  */
 export class ReputationClient extends BaseClient {
   /**
-   * @param config SDK config; `reputationId` MUST be set or the constructor throws.
-   * @throws {SorobanIdentityError} with code `VALIDATION_ERROR` when
-   *   `config.reputationId` is missing.
+   * @param config SDK config including the deployed reputation contract ID.
    */
   constructor(config: SorobanIdentityConfig) {
-    if (!config.reputationId) {
-      throw new SorobanIdentityError('reputationId is required for ReputationClient', 'VALIDATION_ERROR');
-    }
     super(config, config.reputationId);
   }
 
@@ -81,7 +85,7 @@ export class ReputationClient extends BaseClient {
           .addOperation(
             this.contract.call(
               'passes_sybil_check_default',
-              nativeToScVal(PROBE_ADDRESS, { type: 'address' })
+              ...buildPassesSybilCheckDefaultArgs({ subject: PROBE_ADDRESS })
             )
           )
           .setTimeout(10)
@@ -182,7 +186,7 @@ export class ReputationClient extends BaseClient {
       .addOperation(
         this.contract.call(
           'get_reputation',
-          nativeToScVal(subjectAddress, { type: 'address' })
+          ...buildGetReputationArgs({ subject: subjectAddress })
         )
       )
       .setTimeout(timeout)
@@ -256,10 +260,12 @@ export class ReputationClient extends BaseClient {
       .addOperation(
         this.contract.call(
           'get_history',
-          nativeToScVal(subjectAddress, { type: 'address' }),
-          nativeToScVal(reporterAddress, { type: 'address' }),
-          nativeToScVal(offset, { type: 'u32' }),
-          nativeToScVal(limit, { type: 'u32' })
+          ...buildGetHistoryArgs({
+            subject: subjectAddress,
+            reporter: reporterAddress,
+            offset,
+            limit,
+          })
         )
       )
       .setTimeout(timeout)
@@ -310,7 +316,7 @@ export class ReputationClient extends BaseClient {
       .addOperation(
         this.contract.call(
           'passes_sybil_check_default',
-          nativeToScVal(subjectAddress, { type: 'address' })
+          ...buildPassesSybilCheckDefaultArgs({ subject: subjectAddress })
         )
       )
       .setTimeout(timeout)
@@ -361,9 +367,7 @@ export class ReputationClient extends BaseClient {
       .addOperation(
         this.contract.call(
           'passes_sybil_check',
-          nativeToScVal(subjectAddress, { type: 'address' }),
-          nativeToScVal(minScore, { type: 'i64' }),
-          nativeToScVal(minReporters, { type: 'u32' })
+          ...buildPassesSybilCheckArgs({ subject: subjectAddress, minScore, minReporters })
         )
       )
       .setTimeout(timeout)
@@ -409,12 +413,14 @@ export class ReputationClient extends BaseClient {
     // Use the transaction builder for construction
     const builder = new SorobanTransactionBuilder(account, this.config);
     builder.addContractCall(
-      this.config.reputationId!,
+      this.config.reputationId,
       'submit_score',
-      nativeToScVal(reporterKeypair.publicKey(), { type: 'address' }),
-      nativeToScVal(subjectAddress, { type: 'address' }),
-      nativeToScVal(delta, { type: 'i64' }),
-      nativeToScVal(reason, { type: 'string' })
+      ...buildSubmitScoreArgs({
+        reporter: reporterKeypair.publicKey(),
+        subject: subjectAddress,
+        delta,
+        reason,
+      })
     );
 
     const tx = builder.build(timeout);
@@ -526,8 +532,7 @@ export class ReputationClient extends BaseClient {
       .addOperation(
         this.contract.call(
           'list_reporters',
-          cursorArg,
-          nativeToScVal(options?.limit ?? 0, { type: 'u32' })
+          ...buildListReportersArgs({ cursor: cursorArg, limit: options?.limit ?? 0 })
         )
       )
       .setTimeout(timeout)
@@ -585,10 +590,12 @@ export class ReputationClient extends BaseClient {
       .addOperation(
         this.contract.call(
           'list_history',
-          nativeToScVal(subjectAddress, { type: 'address' }),
-          nativeToScVal(reporterAddress, { type: 'address' }),
-          cursorArg,
-          nativeToScVal(options?.limit ?? 0, { type: 'u32' })
+          ...buildListHistoryArgs({
+            subject: subjectAddress,
+            reporter: reporterAddress,
+            cursor: cursorArg,
+            limit: options?.limit ?? 0,
+          })
         )
       )
       .setTimeout(timeout)

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -67,7 +67,8 @@ export interface SorobanIdentityConfig {
   networkPassphrase: string;
   identityRegistryId: string;
   credentialManagerId: string;
-  reputationId?: string;
+  /** Contract ID for the reputation contract. Required when using {@link ReputationClient}. */
+  reputationId: string;
   /** Transaction timeout in seconds. Defaults to 30. */
   txTimeout?: number;
   /** Maximum concurrent RPC requests. Defaults to 5. */


### PR DESCRIPTION
- #227: consolidate CSS color values into custom properties
  - Add --btn-text and --focus-ring tokens to all theme blocks
  - Replace last hardcoded #fff and #7c6af7 literals in rule bodies

- #228: break useWallet into smaller focused hooks
  - useWalletState: raw state atom
  - useWalletConnection: connect/disconnect/auto-reconnect (Freighter + WalletConnect)
  - useFreighterAccountSync: mid-session account-switch polling
  - useWalletSigning: XDR signing for both wallet types
  - useWallet: thin composition layer, public API unchanged
  - Fix WalletContext to use proper ESM import instead of require()

- #229: replace positional Vec args with named argument builders
  - Add sdk/src/contract-args.ts with typed builder functions for all contract methods across identity-registry, credential-manager, reputation
  - Update identity.ts, credentials.ts, reputation.ts to spread named builders
  - Export all builders from sdk/src/index.ts

- #230: unify SorobanIdentityConfig to include all three contract IDs
  - Make reputationId required (was optional with inline intersection type)
  - Remove runtime guard from ReputationClient constructor (now compile-time)
  - Remove non-null assertion on config.reputationId in submitScore

Closes #227
Closes #228
Closes #229
Closes #230