### PR TITLE
refactor: replace tab strings with enum and remove mock data (#225, #…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,10 @@ import {
 import { checkConnection, IdentityClient, CredentialClient, ReputationClient } from "../../sdk/src/index";
 import type { Credential } from "../../sdk/src/types";
 
-type Tab = "identity" | "credentials";
+export enum Tab {
+  Identity = "identity",
+  Credentials = "credentials",
+}
 
 function useDarkMode(): [boolean, () => void] {
   const [isDark, setIsDark] = useState<boolean>(() => {
@@ -37,7 +40,7 @@ function useDarkMode(): [boolean, () => void] {
 }
 
 export default function App() {
-  const [tab, setTab] = useState<Tab>("identity");
+  const [tab, setTab] = useState<Tab>(Tab.Identity);
   const [activeNetwork, setActiveNetwork] = useState<NetworkName>(DEFAULT_NETWORK);
   const [verifyId, setVerifyId] = useState<string | null>(null);
   const networkConfig = NETWORK_CONFIGS[activeNetwork];
@@ -53,7 +56,7 @@ export default function App() {
     const verifyParam = urlParams.get("verify");
     if (verifyParam) {
       setVerifyId(verifyParam);
-      setTab("credentials");
+      setTab(Tab.Credentials);
     }
   }, []);
 
@@ -92,25 +95,10 @@ export default function App() {
     checkInit();
   }, [networkConfig.rpcUrl]);
 
-  // Mock fetch — replace with CredentialClient.getCredentialsBySubject() when wired
+  // TODO: integrate SDK — replace with CredentialClient.getCredentialsBySubject() (see issue #226)
   const fetchCredentials = useCallback(
     async (_address: string): Promise<Credential[]> => {
-      await new Promise((r) => setTimeout(r, 200));
-      const now = Math.floor(Date.now() / 1000);
-      return [
-        {
-          id: "abc003",
-          credentialType: "Reputation",
-          subject: _address,
-          issuer: "GISSUER",
-          claims: {},
-          claimsHash: "mockhash",
-          signature: "",
-          issuedAt: now - 100,
-          expiresAt: now + 3 * 24 * 60 * 60,
-          revoked: false,
-        },
-      ];
+      return [];
     },
     [],
   );
@@ -286,22 +274,22 @@ export default function App() {
 
       <div className="tabs">
         <button
-          className={`tab ${tab === "identity" ? "active" : ""}`}
-          onClick={() => setTab("identity")}
+          className={`tab ${tab === Tab.Identity ? "active" : ""}`}
+          onClick={() => setTab(Tab.Identity)}
         >
           {t("tabs.identity")}
         </button>
         <button
-          className={`tab ${tab === "credentials" ? "active" : ""}`}
-          onClick={() => setTab("credentials")}
+          className={`tab ${tab === Tab.Credentials ? "active" : ""}`}
+          onClick={() => setTab(Tab.Credentials)}
         >
           {t("tabs.credentials")}
         </button>
       </div>
 
       <ErrorBoundary>
-        {tab === "identity" && <IdentityPanel />}
-        {tab === "credentials" && (
+        {tab === Tab.Identity && <IdentityPanel />}
+        {tab === Tab.Credentials && (
           <CredentialsPanel verifyId={verifyId} />
         )}
       </ErrorBoundary>

--- a/frontend/src/components/CredentialsPanel.tsx
+++ b/frontend/src/components/CredentialsPanel.tsx
@@ -100,15 +100,7 @@ function getStatusSortRank(credential: Credential): number {
   return 2;
 }
 
-// Mock credentials for demonstration — replace with SDK data when wired
-const MOCK_CREDENTIALS: Credential[] = [
-  { id: "abc001", credentialType: "Kyc", subject: "GABC…", issuer: "GISSUER", claims: { name: "John Doe", country: "US" }, claimsHash: "hash1", signature: "sig1", issuedAt: Math.floor(Date.now() / 1000) - 1000, expiresAt: 0, revoked: false },
-  { id: "abc002", credentialType: "Kyc", subject: "GABC…", issuer: "GISSUER", claims: { verified: "true" }, claimsHash: "hash2", signature: "sig2", issuedAt: Math.floor(Date.now() / 1000) - 1000, expiresAt: Math.floor((Date.now() + 12 * 24 * 60 * 60 * 1000) / 1000), revoked: false },
-  { id: "abc003", credentialType: "Reputation", subject: "GABC…", issuer: "GISSUER", claims: { score: "850", level: "gold" }, claimsHash: "hash3", signature: "sig3", issuedAt: Math.floor(Date.now() / 1000) - 1000, expiresAt: Math.floor((Date.now() + 3 * 24 * 60 * 60 * 1000) / 1000), revoked: false },
-  { id: "abc004", credentialType: "Achievement", subject: "GABC…", issuer: "GISSUER", claims: {}, claimsHash: "hash4", signature: "sig4", issuedAt: Math.floor(Date.now() / 1000) - 1000, expiresAt: Math.floor((Date.now() - 5 * 24 * 60 * 60 * 1000) / 1000), revoked: false },
-  { id: "abc005", credentialType: "Custom", subject: "GABC…", issuer: "GISSUER", claims: { custom_field: "custom_value" }, claimsHash: "hash5", signature: "sig5", issuedAt: Math.floor(Date.now() / 1000) - 1000, expiresAt: Math.floor((Date.now() + 30 * 24 * 60 * 60 * 1000) / 1000), revoked: true },
-  { id: "abc006", credentialType: "Kyc", subject: "GABC…", issuer: "GISSUER", claims: { reason: "compromised" }, claimsHash: "hash6", signature: "sig6", issuedAt: Math.floor(Date.now() / 1000) - 2000, expiresAt: Math.floor((Date.now() + 30 * 24 * 60 * 60 * 1000) / 1000), revoked: true },
-];
+// TODO: integrate SDK — replace with CredentialClient.getCredentialsBySubject() (see issue #226)
 
 const FILTER_OPTIONS: FilterType[] = ["All", "Kyc", "Reputation", "Achievement", "Custom"];
 
@@ -291,7 +283,7 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
     setClaims(updated);
   };
 
-  const displayCredentials = fetchedCredentials ?? MOCK_CREDENTIALS;
+  const displayCredentials = fetchedCredentials ?? [];
 
   const filteredCredentials =
     activeFilter === "All"
@@ -358,9 +350,9 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
       if (txStatus.status === "FAILED") throw new Error("Transaction failed on-chain");
       
       const raw = scValToNative((txStatus as any).returnValue) as Uint8Array;
-      const mockId = Buffer.from(raw).toString("hex");
+      const credentialId = Buffer.from(raw).toString("hex");
       
-      setIssueResult(`Credential issued successfully!\nID: ${mockId}\nEstimated fee: ${(estimatedFee / 10_000_000).toFixed(7)} XLM`);
+      setIssueResult(`Credential issued successfully!\nID: ${credentialId}\nEstimated fee: ${(estimatedFee / 10_000_000).toFixed(7)} XLM`);
     } catch (e: unknown) {
       setIssueResult(`Error: ${handleError(e)}`);
     } finally {


### PR DESCRIPTION
…226)

Issue #225 — refactor: replace hardcoded tab strings in App.tsx with a typed enum ───────────────────────────────────────────────────────────────────────────────── Problem:
  App.tsx used raw string literals ('identity', 'credentials') for tab state.
  This was error-prone: adding a new tab required hunting every string occurrence,
  and TypeScript could not catch typos or invalid tab values at compile time.

Changes:
  - Replaced  with: export enum Tab { Identity = 'identity', Credentials = 'credentials', }
  - Updated all 5 usages of raw tab strings to use the enum:
      1. useState initial value: useState<Tab>(Tab.Identity)
      2. URL query-param effect: setTab(Tab.Credentials) 3. Identity tab button className comparison: tab === Tab.Identity 4. Credentials tab button className comparison: tab === Tab.Credentials 5. Render conditionals: tab === Tab.Identity / tab === Tab.Credentials
  - Enum is exported so other modules (e.g. deep-link handlers) can import it without re-declaring the values.

Closes #225

Issue #226 — refactor: remove all mock delays and placeholder data from frontend components ──────────────────────────────────────────────────────────────────────────────────────────── Problem:
  Two sources of mock data were left over from UI prototyping:

  1. CredentialsPanel.tsx — MOCK_CREDENTIALS array (6 hardcoded credential objects with fake IDs, subjects, and claims) was used as the fallback when no real search had been performed. This gave a false impression of functionality and would conflict with real SDK data once wired.

  2. App.tsx — fetchCredentials callback used a 200 ms setTimeout and returned a single hardcoded 'Reputation' credential with a fake claimsHash and empty signature. This was passed to useCredentialExpiryCheck, meaning the expiry notification was always driven by fake data.

  3. CredentialsPanel.tsx — the variable holding the on-chain credential ID returned from issue_credential was named , which was misleading since it holds a real hex-encoded return value from the contract.

Changes:
  - Deleted the entire MOCK_CREDENTIALS constant from CredentialsPanel.tsx.
  - Changed the displayCredentials fallback from MOCK_CREDENTIALS to [] so the component renders the empty/search-prompt state until a real SDK search is performed.
  - Replaced the mock fetchCredentials in App.tsx (setTimeout + hardcoded credential) with a no-op async that returns [] and a TODO comment pointing to this issue for future SDK integration.
  - Renamed  →  in the issue_credential handler to accurately reflect that it holds the real on-chain credential ID.

Loading state is already driven by real promise resolution via the credentialReducer (FETCH_START → FETCH_SUCCESS/FETCH_ERROR), so no changes to loading logic were needed.

Closes #226