### PR TITLE
feat(sdk): standardised errors, health check, rate-limit signalling, and type re-exports

### DIFF
--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -18,6 +18,7 @@ export type SorobanErrorCode =
   | "ALREADY_EXISTS"
   | "INVALID_INPUT"
   | "NETWORK_ERROR"
+  | "TIMEOUT"
   | "CONTRACT_ERROR"
   | "RATE_LIMITED"
   | "VALIDATION_ERROR"
@@ -27,6 +28,8 @@ export interface SorobanIdentityErrorInit {
   code?: SorobanErrorCode;
   details?: Record<string, unknown>;
   originalError?: unknown;
+  /** Transaction hash when the failure is tied to an on-chain submission. */
+  txHash?: string;
 }
 
 function isInitObject(v: unknown): v is SorobanIdentityErrorInit {
@@ -54,12 +57,14 @@ export class SorobanIdentityError extends Error {
   readonly details?: Record<string, unknown>;
   /** The underlying error, if this wraps one. */
   readonly originalError?: unknown;
+  /** Transaction hash when the failure is tied to an on-chain submission. */
+  readonly txHash?: string;
 
   /**
    * Backwards-compatible positional signature:
    *   `new SorobanIdentityError(msg, codeString, originalError)`.
    * Init-object signature:
-   *   `new SorobanIdentityError(msg, { code, details, originalError })`.
+   *   `new SorobanIdentityError(msg, { code, details, originalError, txHash })`.
    *
    * @param message       Human-readable error message.
    * @param codeOrInit    {@link SorobanErrorCode} or init object. Defaults to `'UNKNOWN'`.
@@ -76,17 +81,19 @@ export class SorobanIdentityError extends Error {
       this.code = codeOrInit.code ?? "UNKNOWN";
       this.details = codeOrInit.details;
       this.originalError = codeOrInit.originalError ?? originalError;
+      this.txHash = codeOrInit.txHash;
     } else {
       this.code = codeOrInit;
       this.originalError = originalError;
     }
   }
 
-  toEnvelope(): { code: SorobanErrorCode; message: string; details?: Record<string, unknown> } {
+  toEnvelope(): { code: SorobanErrorCode; message: string; details?: Record<string, unknown>; txHash?: string } {
     return {
       code: this.code,
       message: this.message,
       ...(this.details ? { details: this.details } : {}),
+      ...(this.txHash ? { txHash: this.txHash } : {}),
     };
   }
 }
@@ -150,7 +157,8 @@ export function classifyError(message: string): SorobanErrorCode {
   if (/unauthori[sz]ed|forbidden|permission denied/u.test(m)) return "UNAUTHORIZED";
   if (/rate limit|too many requests/u.test(m)) return "RATE_LIMITED";
   if (/invalid|malformed|bad request|missing/u.test(m)) return "INVALID_INPUT";
-  if (/timeout|econnrefused|enotfound|network|fetch failed/u.test(m)) return "NETWORK_ERROR";
+  if (/timed?\s*out|timeout/u.test(m)) return "TIMEOUT";
+  if (/econnrefused|enotfound|network|fetch failed/u.test(m)) return "NETWORK_ERROR";
   if (/#\d+/.test(m)) return "CONTRACT_ERROR";
   return "UNKNOWN";
 }

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -99,6 +99,36 @@ export class SorobanIdentityError extends Error {
 }
 
 /**
+ * Thrown when the RPC provider responds with HTTP 429 and the SDK has
+ * exhausted its retry budget. Consumers should honour `retryAfterMs`
+ * before re-submitting the request.
+ *
+ * @example
+ * ```ts
+ * import { RateLimitError } from '@soroban-identity/sdk';
+ * try {
+ *   await identity.resolveDid(address);
+ * } catch (err) {
+ *   if (err instanceof RateLimitError) {
+ *     await sleep(err.retryAfterMs);
+ *     // retry…
+ *   }
+ * }
+ * ```
+ */
+export class RateLimitError extends Error {
+  /** Milliseconds to wait before the next request attempt. */
+  readonly retryAfterMs: number;
+  readonly code: SorobanErrorCode = "RATE_LIMITED";
+
+  constructor(retryAfterMs: number) {
+    super(`Rate limited — retry after ${retryAfterMs}ms`);
+    this.name = "RateLimitError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/**
  * A typed contract-level error parsed from an RPC simulation failure.
  *
  * Use {@link ContractError.extract} to decode a `#N` marker out of an error

--- a/sdk/src/health.ts
+++ b/sdk/src/health.ts
@@ -10,6 +10,13 @@ export interface HealthCheckResult {
   allHealthy: boolean;
 }
 
+/** Compact liveness result returned by {@link health}. */
+export interface HealthResult {
+  identity: boolean;
+  credentials: boolean;
+  reputation: boolean;
+}
+
 /**
  * Pre-flight health check that pings all three deployed contracts.
  *
@@ -30,6 +37,32 @@ export interface HealthCheckResult {
  * if (!allHealthy) throw new Error('One or more contracts are not reachable');
  * ```
  */
+/**
+ * Ping all three deployed contracts and return compact liveness flags.
+ *
+ * Calls the read-only `ping()` function on each contract in parallel.
+ * A contract is considered unhealthy if its `ping()` throws for any reason.
+ *
+ * @example
+ * ```ts
+ * const { identity, credentials, reputation } = await health(config);
+ * if (!identity) throw new Error('Identity contract unreachable');
+ * ```
+ */
+export async function health(config: SorobanIdentityConfig): Promise<HealthResult> {
+  const [identityResult, credentialResult, reputationResult] = await Promise.allSettled([
+    new IdentityClient(config).ping(),
+    new CredentialClient(config).ping(),
+    new ReputationClient(config).ping(),
+  ]);
+
+  return {
+    identity: identityResult.status === 'fulfilled',
+    credentials: credentialResult.status === 'fulfilled',
+    reputation: reputationResult.status === 'fulfilled',
+  };
+}
+
 export async function healthCheck(config: SorobanIdentityConfig): Promise<HealthCheckResult> {
   const [identityResult, credentialResult, reputationResult] = await Promise.allSettled([
     new IdentityClient(config).ping(),

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -15,6 +15,7 @@ export {
 export {
   ContractError,
   SorobanIdentityError,
+  RateLimitError,
   classifyError,
   wrapError,
 } from './errors';

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -73,8 +73,7 @@ export type {
 export { validateConfig } from './types';
 export type { ReputationRecord, ScoreHistoryEntry } from './reputation';
 export type { EventFilter, ContractEvent, GetEventsOptions } from './events';
-import type { SorobanIdentityConfig } from './types';
-export type { SorobanIdentityConfig, SorobanIdentityLogger };
+export type { SorobanIdentityConfig, SorobanIdentityLogger, WriteResult } from './types';
 
 // Testnet defaults — fill contract IDs after deployment
 export const TESTNET_CONFIG: SorobanIdentityConfig = {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,6 +1,6 @@
 export { IdentityClient } from './identity';
-export { healthCheck } from './health';
-export type { HealthCheckResult } from './health';
+export { health, healthCheck } from './health';
+export type { HealthResult, HealthCheckResult } from './health';
 export { CredentialClient } from './credentials';
 export { ReputationClient } from './reputation';
 export { SorobanEventListener, getEvents } from './events';

--- a/sdk/src/request-queue.ts
+++ b/sdk/src/request-queue.ts
@@ -3,6 +3,8 @@
  * Prevents exhausting RPC quotas and handles 429 responses with retry-after.
  */
 
+import { RateLimitError } from './errors';
+
 interface QueuedRequest<T> {
   fn: () => Promise<T>;
   resolve: (value: T) => void;
@@ -68,10 +70,17 @@ export class RequestQueue {
           this.queue.unshift(request);
           this.processQueue();
         }, delay);
+      } else if (this.is429(error)) {
+        request.reject(new RateLimitError(this.getRetryDelay(error)));
       } else {
         request.reject(error);
       }
     }
+  }
+
+  private is429(error: any): boolean {
+    const errorStr = error?.toString() || '';
+    return errorStr.includes('429') || errorStr.includes('Too Many Requests');
   }
 
   private shouldRetry(error: any, request: QueuedRequest<any>): boolean {


### PR DESCRIPTION
## Summary

This PR resolves four related SDK API quality issues that left consumers unable to handle errors programmatically, verify contract liveness, back off on rate limits, or import public types without reaching into internal paths.

---

### #307 — Standardised error response shape (`sdk/src/errors.ts`)

- Added `TIMEOUT` to the `SorobanErrorCode` union (previously timeout failures fell through to `NETWORK_ERROR`, masking the distinction).
- Added `txHash?: string` to `SorobanIdentityErrorInit` and `SorobanIdentityError` so on-chain submission failures can carry the transaction hash for debuggability.
- `toEnvelope()` now includes `txHash` in its output when present.
- `classifyError` now routes `/timed?\s*out|timeout/` patterns to `TIMEOUT` before the `NETWORK_ERROR` branch so the two codes are mutually exclusive.

### #308 — Health check endpoint (`sdk/src/health.ts`, `sdk/src/index.ts`)

- Added `health(config): Promise<HealthResult>` — a read-only function that calls `ping()` on all three contracts in parallel via `Promise.allSettled` and returns `{ identity: boolean, credentials: boolean, reputation: boolean }`.
- Added the `HealthResult` interface.
- Both `health` and `HealthResult` are now exported from the package root.
- The existing `healthCheck()` and `HealthCheckResult` are kept intact for backwards compatibility.

### #309 — Rate-limit signalling (`sdk/src/errors.ts`, `sdk/src/request-queue.ts`, `sdk/src/index.ts`)

- Added `RateLimitError extends Error` with `retryAfterMs: number` and `code: 'RATE_LIMITED'` so consumers can implement graceful back-off without parsing error message strings.
- `RequestQueue.executeRequest` now throws `RateLimitError` (populated with the extracted `Retry-After` delay) when retries are exhausted on a 429, instead of re-throwing the raw error.
- Extracted `is429(error)` helper to keep the retry/reject branching readable.
- `RateLimitError` is exported from the package root.

### #310 — SDK index.ts re-exports (`sdk/src/index.ts`)

- Fixed a broken re-export: `SorobanIdentityLogger` was listed in `export type { ... }` without a `from` clause, causing a TypeScript compile error since the name was never imported into scope.
- Consolidated `SorobanIdentityConfig` and `SorobanIdentityLogger` into a single `export type { ..., ... } from './types'` statement.
- Added `WriteResult` to the same re-export so consumers can type write-method return values without importing from internal paths.

---

## Files changed

| File | Change |
|------|--------|
| `sdk/src/errors.ts` | `TIMEOUT` code, `txHash` field, `RateLimitError` class, `classifyError` update |
| `sdk/src/health.ts` | `health()` function + `HealthResult` interface |
| `sdk/src/request-queue.ts` | `RateLimitError` throw on exhausted 429 retries, `is429` helper |
| `sdk/src/index.ts` | Export `health`, `HealthResult`, `RateLimitError`, fix `SorobanIdentityLogger`, add `WriteResult` |

Closes #307
Closes #308
Closes #309
Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)