### PR TITLE
fix/feat/docs: typed verification, issuer index, selective disclosure, JSDoc (#311 #312 #313 #314)

### DIFF
--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -399,7 +399,8 @@ impl CredentialManager {
         Ok(())
     }
 
-    /// Verifies that a credential is valid — not revoked and not expired.
+    /// Verifies that a credential is valid and returns a typed result describing
+    /// any failure reason.
     ///
     /// Uses the on-chain ledger timestamp for expiry checks, preventing
     /// caller-supplied time spoofing. Bumps the storage TTL on success so
@@ -410,24 +411,31 @@ impl CredentialManager {
     /// * `credential_id` - The 32-byte ID of the credential to verify.
     ///
     /// # Returns
-    /// `true` if the credential exists, is not revoked, and has not expired.
-    /// `false` otherwise (including if the credential does not exist).
-    pub fn verify_credential(env: Env, credential_id: BytesN<32>) -> bool {
+    /// `Ok(())` if the credential exists, is not revoked, and has not expired.
+    ///
+    /// # Errors
+    /// Returns [`ContractError::CredentialNotFound`] when no credential with the
+    /// given ID exists.
+    /// Returns [`ContractError::CredentialRevoked`] when the credential has been
+    /// revoked.
+    /// Returns [`ContractError::CredentialExpired`] when the credential's
+    /// `expires_at` timestamp has passed (checked against the ledger clock).
+    pub fn verify_credential(env: Env, credential_id: BytesN<32>) -> Result<(), ContractError> {
         let key = Self::cred_key(&credential_id);
         match env.storage().persistent().get::<_, Credential>(&key) {
-            None => false,
+            None => Err(ContractError::CredentialNotFound),
             Some(cred) => {
                 if cred.revoked {
-                    return false;
+                    return Err(ContractError::CredentialRevoked);
                 }
                 let now = env.ledger().timestamp();
                 if cred.expires_at > 0 && now > cred.expires_at {
-                    return false;
+                    return Err(ContractError::CredentialExpired);
                 }
                 // Bump TTL on read for active, non-expired credentials
                 let ttl = Self::ttl_for_credential(&env, cred.expires_at);
                 env.storage().persistent().extend_ttl(&key, ttl, ttl);
-                true
+                Ok(())
             }
         }
     }
@@ -836,7 +844,7 @@ mod tests {
         client.add_issuer(&issuer);
 
         let cred_id = issue_kyc(&env, &client, &issuer, &subject);
-        assert!(client.verify_credential(&cred_id));
+        client.verify_credential(&cred_id);
     }
 
     #[test]
@@ -848,7 +856,10 @@ mod tests {
 
         let cred_id = issue_kyc(&env, &client, &issuer, &subject);
         client.revoke_credential(&issuer, &cred_id);
-        assert!(!client.verify_credential(&cred_id));
+        assert_eq!(
+            client.try_verify_credential(&cred_id),
+            Err(Ok(ContractError::CredentialRevoked))
+        );
     }
 
     #[test]
@@ -911,11 +922,14 @@ mod tests {
             &expires_at,
         );
 
-        assert!(client.verify_credential(&cred_id));
+        client.verify_credential(&cred_id);
         env.ledger().with_mut(|li| {
             li.timestamp = expires_at + 1;
         });
-        assert!(!client.verify_credential(&cred_id));
+        assert_eq!(
+            client.try_verify_credential(&cred_id),
+            Err(Ok(ContractError::CredentialExpired))
+        );
     }
 
     #[test]
@@ -940,7 +954,7 @@ mod tests {
         );
 
         // Credential should be valid immediately
-        assert!(client.verify_credential(&cred_id));
+        client.verify_credential(&cred_id);
 
         // Advance ledger time past expiry
         env.ledger().with_mut(|li| {
@@ -949,7 +963,10 @@ mod tests {
 
         // Credential should now be invalid - verify_credential uses env.ledger().timestamp(),
         // not any caller-provided value, preventing spoofing of time
-        assert!(!client.verify_credential(&cred_id));
+        assert_eq!(
+            client.try_verify_credential(&cred_id),
+            Err(Ok(ContractError::CredentialExpired))
+        );
     }
 
     #[test]
@@ -1132,7 +1149,7 @@ mod tests {
 
         // Re-issuance after revoke must succeed
         let new_id = issue_kyc(&env, &client, &issuer, &subject);
-        assert!(client.verify_credential(&new_id));
+        client.verify_credential(&new_id);
     }
 
     #[test]
@@ -1159,7 +1176,7 @@ mod tests {
         );
 
         // Credential should still be verifiable (TTL was set)
-        assert!(client.verify_credential(&cred_id));
+        client.verify_credential(&cred_id);
     }
 
     #[test]
@@ -1184,8 +1201,8 @@ mod tests {
         );
 
         // Two consecutive verifies — both should succeed (TTL bumped on first)
-        assert!(client.verify_credential(&cred_id));
-        assert!(client.verify_credential(&cred_id));
+        client.verify_credential(&cred_id);
+        client.verify_credential(&cred_id);
     }
 
     #[test]
@@ -1211,8 +1228,11 @@ mod tests {
 
         client.revoke_credential(&issuer, &cred_id);
 
-        // verify_credential returns false for revoked — no TTL bump
-        assert!(!client.verify_credential(&cred_id));
+        // verify_credential returns CredentialRevoked for revoked — no TTL bump
+        assert_eq!(
+            client.try_verify_credential(&cred_id),
+            Err(Ok(ContractError::CredentialRevoked))
+        );
 
         // get_credential returns CredentialRevoked for revoked entries
         let result = client.try_get_credential(&cred_id);

--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -17,6 +17,8 @@ const CRED: Symbol = symbol_short!("CRED");
 const SUBJECT: Symbol = symbol_short!("sub");
 const CRED_CNT: Symbol = symbol_short!("CREDCNT");
 const REVOKED_CNT: Symbol = symbol_short!("REVCNT");
+/// Secondary index: maps each issuer address to the IDs it has issued.
+const ISSUER_CREDS: Symbol = symbol_short!("ISSCREDS");
 
 const MAX_ISSUERS: u32 = 100;
 
@@ -340,6 +342,15 @@ impl CredentialManager {
         env.storage()
             .persistent()
             .extend_ttl(&subject_key, TTL_MAX, TTL_MAX);
+
+        // Index credential under issuer for reverse lookup
+        let mut issuer_creds = Self::fetch_issuer_creds(&env, &issuer);
+        issuer_creds.push_back(id.clone());
+        let issuer_creds_key = Self::issuer_creds_key(&issuer);
+        env.storage().persistent().set(&issuer_creds_key, &issuer_creds);
+        env.storage()
+            .persistent()
+            .extend_ttl(&issuer_creds_key, TTL_MAX, TTL_MAX);
 
         // Increment per-subject credential counter
         let cnt_key = (CRED_CNT, subject.clone());
@@ -674,6 +685,66 @@ impl CredentialManager {
         }
     }
 
+    /// Returns all credential IDs issued by a given issuer address.
+    ///
+    /// The list includes both active and revoked credential IDs. Use
+    /// [`Self::verify_credential`] to check the status of each ID.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `issuer` - The issuer address whose credential IDs to retrieve.
+    pub fn get_issuer_credentials(env: Env, issuer: Address) -> Vec<BytesN<32>> {
+        Self::fetch_issuer_creds(&env, &issuer)
+    }
+
+    /// Returns one page of credential IDs issued by a given issuer, ordered by
+    /// issuance.
+    ///
+    /// Pagination follows the same cursor model as
+    /// [`Self::list_subject_credentials`]: `cursor` is the zero-based start
+    /// index, `limit` is the page size (clamped to [`PAGE_CAP`], `0` →
+    /// `PAGE_CAP`). `next_cursor` is `None` when the iterator is exhausted.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `issuer` - The issuer address whose credential IDs to retrieve.
+    /// * `cursor` - Optional resume index from a prior page's `next_cursor`.
+    /// * `limit` - Maximum items per page (clamped to [`PAGE_CAP`]).
+    pub fn list_issuer_credentials(
+        env: Env,
+        issuer: Address,
+        cursor: Option<u64>,
+        limit: u32,
+    ) -> CredentialIdsPage {
+        let all = Self::fetch_issuer_creds(&env, &issuer);
+        let total = all.len();
+        let start: u64 = cursor.unwrap_or(0);
+
+        let effective_limit: u32 = if limit == 0 || limit > PAGE_CAP {
+            PAGE_CAP
+        } else {
+            limit
+        };
+
+        let mut items: Vec<BytesN<32>> = Vec::new(&env);
+        let mut next: u64 = start;
+        let mut taken: u32 = 0;
+
+        while (next as u32) < total && taken < effective_limit {
+            items.push_back(all.get(next as u32).unwrap());
+            next += 1;
+            taken += 1;
+        }
+
+        let next_cursor = if (next as u32) < total {
+            Some(next)
+        } else {
+            None
+        };
+
+        CredentialIdsPage { items, next_cursor }
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     /// Canonical init guard — see `contracts/README.md`.
@@ -723,6 +794,21 @@ impl CredentialManager {
             .persistent()
             .get(&key)
             .unwrap_or_else(|| Vec::new(env))
+    }
+
+    fn fetch_issuer_creds(env: &Env, issuer: &Address) -> Vec<BytesN<32>> {
+        let key = Self::issuer_creds_key(issuer);
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_MAX, TTL_MAX);
+        }
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    fn issuer_creds_key(issuer: &Address) -> (Symbol, Address) {
+        (ISSUER_CREDS, issuer.clone())
     }
 
     fn derive_id(
@@ -1388,7 +1474,7 @@ mod tests {
     /// Storage namespace symbols must be pairwise distinct.
     #[test]
     fn test_storage_key_symbols_are_unique() {
-        let keys = [ADMIN, ISSUER, CRED, SUBJECT, CRED_CNT, REVOKED_CNT];
+        let keys = [ADMIN, ISSUER, CRED, SUBJECT, CRED_CNT, REVOKED_CNT, ISSUER_CREDS];
         for (i, left) in keys.iter().enumerate() {
             for right in keys.iter().skip(i + 1) {
                 assert_ne!(left, right);

--- a/sdk/src/base-client.ts
+++ b/sdk/src/base-client.ts
@@ -33,6 +33,14 @@ const noopLogger: SorobanIdentityLogger = {
   debug: () => undefined,
 };
 
+/**
+ * Abstract base class shared by all SDK clients.
+ *
+ * Provides RPC endpoint failover across multiple `rpcUrl` entries, a
+ * concurrency-controlled {@link RequestQueue}, and a pluggable
+ * {@link SorobanIdentityLogger}. Concrete clients extend this class and add
+ * contract-specific methods.
+ */
 export abstract class BaseClient {
   protected servers: SorobanRpc.Server[];
   protected currentServerIndex = 0;
@@ -41,6 +49,10 @@ export abstract class BaseClient {
   protected requestQueue: RequestQueue;
   protected logger: SorobanIdentityLogger;
 
+  /**
+   * @param config     SDK configuration including one or more RPC URLs.
+   * @param contractId Deployed contract ID that this client wraps.
+   */
   constructor(config: SorobanIdentityConfig, contractId: string) {
     this.config = config;
 
@@ -64,6 +76,18 @@ export abstract class BaseClient {
     this.logger.debug(message, meta);
   }
 
+  /**
+   * Execute `fn` against the current RPC server, failing over to the next URL
+   * in the pool on 5xx / connection errors. Updates `currentServerIndex` on
+   * a successful attempt so future calls prefer the healthy endpoint.
+   *
+   * Contract-level errors (non-network) are NOT retried — only transport
+   * failures trigger failover.
+   *
+   * @param fn Async function that receives the active {@link SorobanRpc.Server}.
+   * @returns The value returned by `fn` on the first successful attempt.
+   * @throws The last error encountered if all servers fail.
+   */
   protected async executeWithFailover<T>(fn: (server: SorobanRpc.Server) => Promise<T>): Promise<T> {
     return this.requestQueue.enqueue(async () => {
       let lastError: any;

--- a/sdk/src/contract-args.ts
+++ b/sdk/src/contract-args.ts
@@ -14,6 +14,13 @@ import type { CredentialType } from './types';
 
 // ── identity-registry ────────────────────────────────────────────────────────
 
+/**
+ * Build args for `create_did(controller, metadata)`.
+ *
+ * @param params.controller Stellar address that will control the new DID.
+ * @param params.metadata   Arbitrary `string → string` map to embed.
+ * @returns ScVal array ready for `contract.call('create_did', ...)`.
+ */
 export function buildCreateDidArgs(params: {
   controller: string;
   metadata: Record<string, string>;
@@ -24,6 +31,13 @@ export function buildCreateDidArgs(params: {
   ];
 }
 
+/**
+ * Build args for `update_did(controller, metadata)`.
+ *
+ * @param params.controller Stellar address of the DID controller (must sign).
+ * @param params.metadata   Replacement `string → string` metadata map.
+ * @returns ScVal array ready for `contract.call('update_did', ...)`.
+ */
 export function buildUpdateDidArgs(params: {
   controller: string;
   metadata: Record<string, string>;
@@ -34,18 +48,36 @@ export function buildUpdateDidArgs(params: {
   ];
 }
 
+/**
+ * Build args for `resolve_did(controller)`.
+ *
+ * @param params.controller Stellar address whose DID document to retrieve.
+ * @returns ScVal array ready for `contract.call('resolve_did', ...)`.
+ */
 export function buildResolveDidArgs(params: {
   controller: string;
 }): xdr.ScVal[] {
   return [nativeToScVal(params.controller, { type: 'address' })];
 }
 
+/**
+ * Build args for `has_active_did(controller)`.
+ *
+ * @param params.controller Stellar address to check for an active DID.
+ * @returns ScVal array ready for `contract.call('has_active_did', ...)`.
+ */
 export function buildHasActiveDidArgs(params: {
   controller: string;
 }): xdr.ScVal[] {
   return [nativeToScVal(params.controller, { type: 'address' })];
 }
 
+/**
+ * Build args for `deactivate_did(controller)`.
+ *
+ * @param params.controller Stellar address of the DID controller (must sign).
+ * @returns ScVal array ready for `contract.call('deactivate_did', ...)`.
+ */
 export function buildDeactivateDidArgs(params: {
   controller: string;
 }): xdr.ScVal[] {
@@ -54,6 +86,19 @@ export function buildDeactivateDidArgs(params: {
 
 // ── credential-manager ───────────────────────────────────────────────────────
 
+/**
+ * Build args for `issue_credential(issuer, subject, credential_type, claims,
+ * claims_hash, signature, expires_at)`.
+ *
+ * @param params.issuer         Registered issuer address (must sign the tx).
+ * @param params.subject        Subject receiving the credential.
+ * @param params.credentialType Credential category — see {@link CredentialType}.
+ * @param params.claims         Arbitrary `string → string` claims map.
+ * @param params.claimsHash     32-byte SHA-256 of the off-chain claims payload.
+ * @param params.signature      64-byte issuer Ed25519 signature.
+ * @param params.expiresAt      Unix timestamp (seconds); `0` for no expiry.
+ * @returns ScVal array ready for `contract.call('issue_credential', ...)`.
+ */
 export function buildIssueCredentialArgs(params: {
   issuer: string;
   subject: string;
@@ -74,36 +119,75 @@ export function buildIssueCredentialArgs(params: {
   ];
 }
 
+/**
+ * Build args for `verify_credential(credential_id)`.
+ *
+ * @param params.credentialId 32-byte credential ID buffer.
+ * @returns ScVal array ready for `contract.call('verify_credential', ...)`.
+ */
 export function buildVerifyCredentialArgs(params: {
   credentialId: Buffer;
 }): xdr.ScVal[] {
   return [nativeToScVal(params.credentialId, { type: 'bytes' })];
 }
 
+/**
+ * Build args for `get_credential(credential_id)`.
+ *
+ * @param params.credentialId 32-byte credential ID buffer.
+ * @returns ScVal array ready for `contract.call('get_credential', ...)`.
+ */
 export function buildGetCredentialArgs(params: {
   credentialId: Buffer;
 }): xdr.ScVal[] {
   return [nativeToScVal(params.credentialId, { type: 'bytes' })];
 }
 
+/**
+ * Build args for `get_subject_credentials(subject)`.
+ *
+ * @param params.subject Stellar address of the credential subject.
+ * @returns ScVal array ready for `contract.call('get_subject_credentials', ...)`.
+ */
 export function buildGetSubjectCredentialsArgs(params: {
   subject: string;
 }): xdr.ScVal[] {
   return [nativeToScVal(params.subject, { type: 'address' })];
 }
 
+/**
+ * Build args for `is_issuer(address)`.
+ *
+ * @param params.address Stellar address to check for issuer membership.
+ * @returns ScVal array ready for `contract.call('is_issuer', ...)`.
+ */
 export function buildIsIssuerArgs(params: {
   address: string;
 }): xdr.ScVal[] {
   return [nativeToScVal(params.address, { type: 'address' })];
 }
 
+/**
+ * Build args for `get_credential_count(subject)`.
+ *
+ * @param params.subject Stellar address whose credential count to retrieve.
+ * @returns ScVal array ready for `contract.call('get_credential_count', ...)`.
+ */
 export function buildGetCredentialCountArgs(params: {
   subject: string;
 }): xdr.ScVal[] {
   return [nativeToScVal(params.subject, { type: 'address' })];
 }
 
+/**
+ * Build args for `list_subject_credentials(subject, cursor, limit, credential_type)`.
+ *
+ * @param params.subject  Stellar address of the credential subject.
+ * @param params.cursor   Pre-encoded `Option<u64>` ScVal for the resume cursor.
+ * @param params.limit    Maximum items per page; `0` uses the contract's cap.
+ * @param params.filter   Pre-encoded `Option<CredentialType>` ScVal filter.
+ * @returns ScVal array ready for `contract.call('list_subject_credentials', ...)`.
+ */
 export function buildListSubjectCredentialsArgs(params: {
   subject: string;
   cursor: xdr.ScVal;
@@ -118,6 +202,13 @@ export function buildListSubjectCredentialsArgs(params: {
   ];
 }
 
+/**
+ * Build args for `list_issuers(cursor, limit)`.
+ *
+ * @param params.cursor Pre-encoded `Option<u64>` ScVal for the resume cursor.
+ * @param params.limit  Maximum items per page; `0` uses the contract's cap.
+ * @returns ScVal array ready for `contract.call('list_issuers', ...)`.
+ */
 export function buildListIssuersArgs(params: {
   cursor: xdr.ScVal;
   limit: number;
@@ -128,12 +219,26 @@ export function buildListIssuersArgs(params: {
   ];
 }
 
+/**
+ * Build args for `get_issuer_credentials(issuer)`.
+ *
+ * @param params.issuer Stellar address of the issuer.
+ * @returns ScVal array ready for `contract.call('get_issuer_credentials', ...)`.
+ */
 export function buildGetIssuerCredentialsArgs(params: {
   issuer: string;
 }): xdr.ScVal[] {
   return [nativeToScVal(params.issuer, { type: 'address' })];
 }
 
+/**
+ * Build args for `list_issuer_credentials(issuer, cursor, limit)`.
+ *
+ * @param params.issuer  Stellar address of the issuer.
+ * @param params.cursor  Pre-encoded `Option<u64>` ScVal for the resume cursor.
+ * @param params.limit   Maximum items per page; `0` uses the contract's cap.
+ * @returns ScVal array ready for `contract.call('list_issuer_credentials', ...)`.
+ */
 export function buildListIssuerCredentialsArgs(params: {
   issuer: string;
   cursor: xdr.ScVal;
@@ -148,12 +253,27 @@ export function buildListIssuerCredentialsArgs(params: {
 
 // ── reputation ───────────────────────────────────────────────────────────────
 
+/**
+ * Build args for `get_reputation(subject)`.
+ *
+ * @param params.subject Stellar address whose reputation record to retrieve.
+ * @returns ScVal array ready for `contract.call('get_reputation', ...)`.
+ */
 export function buildGetReputationArgs(params: {
   subject: string;
 }): xdr.ScVal[] {
   return [nativeToScVal(params.subject, { type: 'address' })];
 }
 
+/**
+ * Build args for `get_history(subject, reporter, offset, limit)`.
+ *
+ * @param params.subject   Stellar address of the credential subject.
+ * @param params.reporter  Registered reporter address.
+ * @param params.offset    Number of entries to skip (offset-based pagination).
+ * @param params.limit     Maximum entries to return.
+ * @returns ScVal array ready for `contract.call('get_history', ...)`.
+ */
 export function buildGetHistoryArgs(params: {
   subject: string;
   reporter: string;
@@ -168,12 +288,26 @@ export function buildGetHistoryArgs(params: {
   ];
 }
 
+/**
+ * Build args for `passes_sybil_check_default(subject)`.
+ *
+ * @param params.subject Stellar address to evaluate against stored thresholds.
+ * @returns ScVal array ready for `contract.call('passes_sybil_check_default', ...)`.
+ */
 export function buildPassesSybilCheckDefaultArgs(params: {
   subject: string;
 }): xdr.ScVal[] {
   return [nativeToScVal(params.subject, { type: 'address' })];
 }
 
+/**
+ * Build args for `passes_sybil_check(subject, min_score, min_reporters)`.
+ *
+ * @param params.subject       Stellar address to evaluate.
+ * @param params.minScore      Minimum accumulated score required to pass.
+ * @param params.minReporters  Minimum distinct active reporters required.
+ * @returns ScVal array ready for `contract.call('passes_sybil_check', ...)`.
+ */
 export function buildPassesSybilCheckArgs(params: {
   subject: string;
   minScore: number;
@@ -186,6 +320,15 @@ export function buildPassesSybilCheckArgs(params: {
   ];
 }
 
+/**
+ * Build args for `submit_score(reporter, subject, delta, reason)`.
+ *
+ * @param params.reporter Registered reporter address (must sign the tx).
+ * @param params.subject  Subject receiving the score delta.
+ * @param params.delta    Signed score change (positive or negative).
+ * @param params.reason   Human-readable reason string; length-capped on-chain.
+ * @returns ScVal array ready for `contract.call('submit_score', ...)`.
+ */
 export function buildSubmitScoreArgs(params: {
   reporter: string;
   subject: string;
@@ -200,6 +343,13 @@ export function buildSubmitScoreArgs(params: {
   ];
 }
 
+/**
+ * Build args for `list_reporters(cursor, limit)`.
+ *
+ * @param params.cursor Pre-encoded `Option<u64>` ScVal for the resume cursor.
+ * @param params.limit  Maximum items per page; `0` uses the contract's cap.
+ * @returns ScVal array ready for `contract.call('list_reporters', ...)`.
+ */
 export function buildListReportersArgs(params: {
   cursor: xdr.ScVal;
   limit: number;
@@ -210,6 +360,15 @@ export function buildListReportersArgs(params: {
   ];
 }
 
+/**
+ * Build args for `list_history(subject, reporter, cursor, limit)`.
+ *
+ * @param params.subject   Stellar address of the credential subject.
+ * @param params.reporter  Registered reporter address.
+ * @param params.cursor    Pre-encoded `Option<u64>` ScVal for the resume cursor.
+ * @param params.limit     Maximum items per page; `0` uses the contract's cap.
+ * @returns ScVal array ready for `contract.call('list_history', ...)`.
+ */
 export function buildListHistoryArgs(params: {
   subject: string;
   reporter: string;

--- a/sdk/src/contract-args.ts
+++ b/sdk/src/contract-args.ts
@@ -128,6 +128,24 @@ export function buildListIssuersArgs(params: {
   ];
 }
 
+export function buildGetIssuerCredentialsArgs(params: {
+  issuer: string;
+}): xdr.ScVal[] {
+  return [nativeToScVal(params.issuer, { type: 'address' })];
+}
+
+export function buildListIssuerCredentialsArgs(params: {
+  issuer: string;
+  cursor: xdr.ScVal;
+  limit: number;
+}): xdr.ScVal[] {
+  return [
+    nativeToScVal(params.issuer, { type: 'address' }),
+    params.cursor,
+    nativeToScVal(params.limit, { type: 'u32' }),
+  ];
+}
+
 // ── reputation ───────────────────────────────────────────────────────────────
 
 export function buildGetReputationArgs(params: {

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -37,9 +37,9 @@ import {
 } from "./contract-args";
 
 const PROBE_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
-const CREDENTIAL_VERIFY_NOT_FOUND_CODE = 2;
 const CREDENTIAL_NOT_FOUND_CODE = 3;
 const CREDENTIAL_REVOKED_CODE = 4;
+const CREDENTIAL_EXPIRED_CODE = 9;
 
 /**
  * Client for the credential-manager contract.
@@ -213,19 +213,33 @@ export class CredentialClient extends BaseClient {
   }
 
   /**
-   * Verify a credential is valid (not revoked, not expired).
+   * Verify a credential and get a typed result describing any failure reason.
    *
-   * Read-only simulation. Returns a discriminated {@link VerifyResult} so
-   * callers can branch on the failure reason without parsing error strings.
+   * Read-only simulation. The contract now returns `Result<(), ContractError>`
+   * so every failure mode is surfaced as a named reason — no secondary
+   * credential fetch is needed.
    *
    * @param callerAddress Stellar address used to build the read simulation.
    * @param credentialId  Hex-encoded credential ID (32 bytes).
    * @param options       Per-call overrides (currently `timeoutSeconds`).
    * @returns `{ valid: true }` when the credential is active and unexpired;
-   *   otherwise `{ valid: false, reason }` where reason is one of
-   *   `not_found`, `revoked`, `expired`, or `unknown`.
+   *   otherwise `{ valid: false, reason? }` where `reason` is one of
+   *   `EXPIRED`, `REVOKED`, `UNKNOWN_ISSUER`, `INVALID_SIGNATURE`, or
+   *   `INACTIVE_SUBJECT` when the contract supplies a typed error code.
    * @throws {SorobanIdentityError} on simulation failure unrelated to a
    *   verification result (network errors, malformed `callerAddress`).
+   *
+   * @example
+   * ```ts
+   * const result = await credentials.verifyCredential(caller, credentialId);
+   * if (!result.valid) {
+   *   switch (result.reason) {
+   *     case 'REVOKED': handleRevoked(); break;
+   *     case 'EXPIRED': handleExpired(); break;
+   *     case 'UNKNOWN_ISSUER': handleUnknownIssuer(); break;
+   *   }
+   * }
+   * ```
    */
   async verifyCredential(
     callerAddress: string,
@@ -257,35 +271,20 @@ export class CredentialClient extends BaseClient {
     if (isSimulationError) {
       const error: string = (result as { error: string }).error ?? "";
       const contractErr = ContractError.extract(error, CREDENTIAL_MANAGER_ERRORS);
-      if (contractErr?.code === CREDENTIAL_VERIFY_NOT_FOUND_CODE) return { valid: false, reason: "not_found" };
-      if (contractErr?.code === CREDENTIAL_REVOKED_CODE) return { valid: false, reason: "revoked" };
-      if (contractErr?.code === 5) return { valid: false, reason: "expired" };
-      if (error.includes("credential not found")) {
-        return { valid: false, reason: "not_found" };
+      if (contractErr?.code === CREDENTIAL_NOT_FOUND_CODE) {
+        return { valid: false, reason: 'UNKNOWN_ISSUER' };
       }
-      return { valid: false, reason: "unknown" };
+      if (contractErr?.code === CREDENTIAL_REVOKED_CODE) {
+        return { valid: false, reason: 'REVOKED' };
+      }
+      if (contractErr?.code === CREDENTIAL_EXPIRED_CODE) {
+        return { valid: false, reason: 'EXPIRED' };
+      }
+      return { valid: false };
     }
 
-    const valid = scValToNative(
-      (result as SorobanRpc.Api.SimulateTransactionSuccessResponse)
-        .result!.retval
-    ) as boolean;
-
-    if (valid) return { valid: true };
-
-    // Contract returned false — fetch the credential to determine why
-    try {
-      const cred = await this.getCredential(callerAddress, credentialId);
-      if (cred.revoked) return { valid: false, reason: "revoked" };
-      if (cred.expiresAt > 0 && Date.now() / 1000 > cred.expiresAt) {
-        return { valid: false, reason: "expired" };
-      }
-    } catch {
-      // getCredential failed — credential likely doesn't exist
-      return { valid: false, reason: "not_found" };
-    }
-
-    return { valid: false, reason: "unknown" };
+    // Contract returned Ok(()) — credential is active and unexpired
+    return { valid: true };
   }
 
   /**

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -34,6 +34,8 @@ import {
   buildGetCredentialCountArgs,
   buildListSubjectCredentialsArgs,
   buildListIssuersArgs,
+  buildGetIssuerCredentialsArgs,
+  buildListIssuerCredentialsArgs,
 } from "./contract-args";
 
 const PROBE_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
@@ -763,6 +765,149 @@ export class CredentialClient extends BaseClient {
     ) as { items: string[]; next_cursor: number | null };
 
     return { items: raw.items, nextCursor: raw.next_cursor ?? null };
+  }
+
+  /**
+   * Get all credentials issued by an issuer address.
+   *
+   * Returns full credential records resolved via
+   * {@link CredentialClient.getCredential} for each ID from the issuer index.
+   * Includes revoked credentials — callers can drop them by inspecting
+   * `revoked`.
+   *
+   * **Note:** For large issuers use the paginated
+   * {@link CredentialClient.listCredentialsByIssuer}.
+   *
+   * @param callerAddress  Stellar address used to build the read simulation.
+   * @param issuerAddress  The issuer address whose credentials to retrieve.
+   * @param options        Per-call overrides (currently `timeoutSeconds`).
+   * @returns Array of {@link Credential} records issued by `issuerAddress`.
+   * @throws {SorobanIdentityError} on simulation failure.
+   *
+   * @example
+   * ```ts
+   * const issued = await credentials.getCredentialsByIssuer(caller, issuerAddress);
+   * const active = issued.filter(c => !c.revoked);
+   * ```
+   */
+  async getCredentialsByIssuer(
+    callerAddress: string,
+    issuerAddress: string,
+    options?: CallOptions
+  ): Promise<Credential[]> {
+    validateStellarAddress(callerAddress);
+    validateStellarAddress(issuerAddress);
+    const account = await this.server.getAccount(callerAddress);
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
+
+    const idsTx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          'get_issuer_credentials',
+          ...buildGetIssuerCredentialsArgs({ issuer: issuerAddress })
+        )
+      )
+      .setTimeout(timeout)
+      .build();
+
+    const idsResult = await retryWithBackoff(() => this.server.simulateTransaction(idsTx));
+    const idsSimulationError = SorobanRpc.Api.isSimulationError(idsResult);
+    this.debug('sdk.simulation_result', { operation: 'credentials.getCredentialsByIssuer.ids', success: !idsSimulationError });
+    if (idsSimulationError) {
+      const errMsg = idsResult.error ?? '';
+      const contractErr = ContractError.extract(errMsg, CREDENTIAL_MANAGER_ERRORS);
+      if (contractErr) throw contractErr;
+      throw new SorobanIdentityError(`Simulation failed: ${errMsg}`, 'CONTRACT_ERROR');
+    }
+
+    const ids = scValToNative(
+      (idsResult as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval
+    ) as Uint8Array[];
+
+    if (!ids || ids.length === 0) return [];
+
+    return Promise.all(
+      ids.map((raw) =>
+        this.getCredential(callerAddress, Buffer.from(raw).toString('hex'), options)
+      )
+    );
+  }
+
+  /**
+   * Cursor-paginated variant of {@link CredentialClient.getCredentialsByIssuer}.
+   *
+   * Returns credential IDs only. Use {@link CredentialClient.getCredential} to
+   * resolve full records as needed.
+   *
+   * @param callerAddress  Stellar address used to build the read-only simulation.
+   * @param issuerAddress  The issuer address whose credential IDs to retrieve.
+   * @param options        Pagination + per-call overrides.
+   * @returns Page of credential IDs (hex-encoded) with the next resume cursor.
+   * @throws {SorobanIdentityError} on simulation failure.
+   *
+   * @example
+   * ```ts
+   * let cursor: number | undefined;
+   * const ids: string[] = [];
+   * do {
+   *   const page = await credentials.listCredentialsByIssuer(caller, issuerAddress, {
+   *     cursor,
+   *     limit: 50,
+   *   });
+   *   ids.push(...page.items);
+   *   cursor = page.nextCursor ?? undefined;
+   * } while (cursor !== undefined);
+   * ```
+   */
+  async listCredentialsByIssuer(
+    callerAddress: string,
+    issuerAddress: string,
+    options?: PaginationOptions
+  ): Promise<Page<string>> {
+    validateStellarAddress(callerAddress);
+    validateStellarAddress(issuerAddress);
+    const account = await this.server.getAccount(callerAddress);
+    const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
+    const cursorArg = options?.cursor === undefined
+      ? nativeToScVal(null, { type: 'option' })
+      : nativeToScVal({ Some: options.cursor }, { type: { Some: ['u64'] } as never });
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          'list_issuer_credentials',
+          ...buildListIssuerCredentialsArgs({
+            issuer: issuerAddress,
+            cursor: cursorArg,
+            limit: options?.limit ?? 0,
+          })
+        )
+      )
+      .setTimeout(timeout)
+      .build();
+
+    const result = await retryWithBackoff(() => this.server.simulateTransaction(tx));
+    if (SorobanRpc.Api.isSimulationError(result)) {
+      const errMsg = result.error ?? '';
+      const contractErr = ContractError.extract(errMsg, CREDENTIAL_MANAGER_ERRORS);
+      if (contractErr) throw contractErr;
+      throw new SorobanIdentityError(`Simulation failed: ${errMsg}`, 'CONTRACT_ERROR');
+    }
+
+    const raw = scValToNative(
+      (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval
+    ) as { items: Uint8Array[]; next_cursor: number | null };
+
+    return {
+      items: raw.items.map((b) => Buffer.from(b).toString('hex')),
+      nextCursor: raw.next_cursor ?? null,
+    };
   }
 
   /**

--- a/sdk/src/events.ts
+++ b/sdk/src/events.ts
@@ -1,21 +1,33 @@
 import { SorobanRpc, Contract, xdr, scValToNative } from '@stellar/stellar-sdk';
 
+/** Filter applied to an event subscription or one-shot query. */
 export interface EventFilter {
+  /** Topic filter — single topic array or matrix of OR-able topics. */
   topic?: string[] | string[][];
+  /** Restrict results to events from this contract ID. */
   contractId?: string;
 }
 
+/** Decoded Soroban contract event returned by {@link getEvents} or the listener callback. */
 export interface ContractEvent {
   type: string;
+  /** Stellar contract ID that emitted this event. */
   contractId: string;
+  /** JSON-serialised topic values. */
   topic: string[];
+  /** Decoded event payload. */
   value: Record<string, unknown>;
+  /** Ledger sequence number the event was emitted in. */
   ledger: number;
+  /** Transaction hash of the transaction that produced this event. */
   txHash: string;
 }
 
+/** Options for a one-shot historical event query via {@link getEvents}. */
 export interface GetEventsOptions {
+  /** Soroban RPC URL to query. */
   rpcUrl: string;
+  /** Contract whose events to fetch. */
   contractId: string;
   /** Ledger to start scanning from. Omit to start from the oldest available. */
   startLedger?: number;
@@ -25,14 +37,19 @@ export interface GetEventsOptions {
 }
 
 /**
- * One-shot fetch of historical contract events via the Soroban RPC getEvents
- * endpoint. For real-time updates use SorobanEventListener instead.
+ * One-shot fetch of historical contract events via the Soroban RPC `getEvents`
+ * endpoint.
  *
- * Event indexing strategy:
- *   - For lightweight queries: call this utility with a known startLedger.
- *   - For production indexing: consider the Mercury indexer for Soroban
- *     (https://mercurydata.app) or run a custom listener that checkpoints
- *     the last processed ledger and pages forward on each invocation.
+ * For real-time updates use {@link SorobanEventListener} instead.
+ *
+ * **Indexing strategy:** For lightweight queries, call this utility with a
+ * known `startLedger`. For production indexing, consider checkpointing the
+ * last processed ledger and paging forward on each invocation.
+ *
+ * @param options Query parameters — RPC URL, contract, ledger range, and filter.
+ * @returns Array of decoded {@link ContractEvent} records. Empty when no events
+ *   match.
+ * @throws If the RPC request fails.
  */
 export async function getEvents(options: GetEventsOptions): Promise<ContractEvent[]> {
   const { rpcUrl, contractId, startLedger, limit = 100, filter } = options;
@@ -83,6 +100,23 @@ function parseRawEvent(event: SorobanRpc.Api.EventResponse): ContractEvent | nul
   }
 }
 
+/**
+ * Long-running, polling-based listener for real-time Soroban contract events.
+ *
+ * Polls the RPC `getEvents` endpoint at a configurable interval and delivers
+ * new events to a callback. Tracks the last seen ledger so each poll returns
+ * only fresh events.
+ *
+ * @example
+ * ```ts
+ * const listener = new SorobanEventListener(rpcUrl, contractId, {
+ *   topic: ['credential', 'issued'],
+ * });
+ * listener.start((events) => console.log(events));
+ * // later...
+ * listener.stop();
+ * ```
+ */
 export class SorobanEventListener {
   private server: SorobanRpc.Server;
   private contractId: string;
@@ -91,6 +125,11 @@ export class SorobanEventListener {
   private intervalId?: ReturnType<typeof setInterval>;
   private lastLedger = 0;
 
+  /**
+   * @param rpcUrl     Soroban RPC endpoint URL.
+   * @param contractId Contract whose events to subscribe to.
+   * @param filter     Optional topic / contract-ID filter applied to each poll.
+   */
   constructor(rpcUrl: string, contractId: string, filter?: EventFilter) {
     this.server = new SorobanRpc.Server(rpcUrl);
     this.contractId = contractId;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -52,6 +52,8 @@ export {
   buildSubmitScoreArgs,
   buildListReportersArgs,
   buildListHistoryArgs,
+  buildGetIssuerCredentialsArgs,
+  buildListIssuerCredentialsArgs,
 } from './contract-args';
 export type {
   DidDocument,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -3,6 +3,14 @@ export { healthCheck } from './health';
 export type { HealthCheckResult } from './health';
 export { CredentialClient } from './credentials';
 export { ReputationClient } from './reputation';
+export { PresentationClient } from './presentation';
+export type {
+  VerifiablePresentation,
+  VerifiableCredentialSubset,
+  PresentationProof,
+  PresentationVerifyResult,
+  PresentationVerifyFailReason,
+} from './presentation';
 export { SorobanEventListener, getEvents } from './events';
 export { SorobanTransactionBuilder } from './transaction-builder';
 export { RequestQueue } from './request-queue';

--- a/sdk/src/presentation.ts
+++ b/sdk/src/presentation.ts
@@ -1,0 +1,261 @@
+import { randomBytes, createHash } from 'node:crypto';
+import type { Credential } from './types';
+
+// ── W3C VC Data Model 2.0 types ─────────────────────────────────────────────
+
+/**
+ * A selective-disclosure credential envelope embedded in a
+ * {@link VerifiablePresentation}. Contains only the claim fields the holder
+ * chose to disclose; the `claimsHash` lets verifiers confirm the disclosed
+ * claims against the on-chain hash via `verify_claims_hash`.
+ */
+export interface VerifiableCredentialSubset {
+  '@context': string[];
+  type: string[];
+  /** Hex-encoded credential ID matching the on-chain record. */
+  id: string;
+  /** Stellar address of the issuer formatted as `did:stellar:<address>`. */
+  issuer: string;
+  credentialSubject: {
+    /** Stellar address of the subject formatted as `did:stellar:<address>`. */
+    id: string;
+    [claim: string]: string;
+  };
+  /** Canonical credential type label (`Kyc`, `Reputation`, etc.). */
+  credentialType: string;
+  /** Hex SHA-256 of the full off-chain claims payload (from the on-chain record). */
+  claimsHash: string;
+  /** Unix timestamp (seconds) of original issuance. */
+  issuedAt: number;
+  /** Unix timestamp (seconds) after which the credential is invalid. 0 = no expiry. */
+  expiresAt: number;
+}
+
+/**
+ * Lightweight proof block attached to a {@link VerifiablePresentation}.
+ * Follows the W3C Data Integrity Proof structure.
+ */
+export interface PresentationProof {
+  type: 'DataIntegrityProof';
+  /** Unix timestamp (ms) when the proof was created. */
+  created: number;
+  proofPurpose: 'authentication' | 'assertionMethod';
+  cryptosuite: string;
+  /** `did:stellar:<address>#key-1` of the signing key. */
+  verificationMethod?: string;
+  /** Base64url-encoded Ed25519 signature over the canonical presentation JSON. */
+  jws?: string;
+}
+
+/**
+ * W3C VC Data Model 2.0 Verifiable Presentation with selective disclosure.
+ *
+ * Created by {@link PresentationClient.createPresentation}; verified by
+ * {@link PresentationClient.verifyPresentation}.
+ */
+export interface VerifiablePresentation {
+  '@context': string[];
+  type: string[];
+  /** Unique presentation ID (`urn:presentation:<hex>`). */
+  id: string;
+  /** DID (`did:stellar:<address>`) of the entity presenting the credential. */
+  holder?: string;
+  verifiableCredential: VerifiableCredentialSubset[];
+  proof?: PresentationProof;
+  /** Unix timestamp (ms) when the presentation was created. */
+  created: number;
+}
+
+// ── Verification result ──────────────────────────────────────────────────────
+
+/**
+ * Reason a {@link VerifiablePresentation} failed structural verification.
+ *
+ * - `INVALID_CONTEXT` — the required W3C context URL is absent.
+ * - `INVALID_TYPE` — `VerifiablePresentation` is not in the `type` array.
+ * - `MISSING_CREDENTIALS` — `verifiableCredential` is empty or absent.
+ * - `INCOMPLETE_CREDENTIAL` — a credential subset is missing required fields.
+ * - `MISSING_CLAIMS` — a credential subset has no `credentialSubject` claims.
+ */
+export type PresentationVerifyFailReason =
+  | 'INVALID_CONTEXT'
+  | 'INVALID_TYPE'
+  | 'MISSING_CREDENTIALS'
+  | 'INCOMPLETE_CREDENTIAL'
+  | 'MISSING_CLAIMS';
+
+/**
+ * Result from {@link PresentationClient.verifyPresentation}.
+ *
+ * `valid` is `true` when the presentation passes all structural checks.
+ * `reason` is present when `valid` is `false`.
+ */
+export type PresentationVerifyResult =
+  | { valid: true }
+  | { valid: false; reason: PresentationVerifyFailReason };
+
+// ── PresentationClient ───────────────────────────────────────────────────────
+
+const W3C_VC_CONTEXT_V2 = 'https://www.w3.org/ns/credentials/v2';
+
+/**
+ * Client for creating and verifying W3C VC Data Model 2.0 Verifiable
+ * Presentations with selective disclosure.
+ *
+ * **Selective disclosure flow:**
+ * 1. Holder calls {@link PresentationClient.createPresentation} with the
+ *    full credential and the list of claim fields to share.
+ * 2. The presentation is sent to a relying party containing only the chosen
+ *    claims alongside the on-chain `claimsHash`.
+ * 3. Relying party calls {@link PresentationClient.verifyPresentation} for
+ *    structural checks, then uses `CredentialClient.verifyCredential` and
+ *    the contract's `verify_claims_hash` for on-chain validation.
+ *
+ * @example
+ * ```ts
+ * import { PresentationClient } from '@soroban-identity/sdk';
+ *
+ * const client = new PresentationClient();
+ *
+ * // Holder creates a presentation disclosing only 'name' and 'country'
+ * const vp = client.createPresentation(credential, ['name', 'country'], holderAddress);
+ *
+ * // Relying party verifies the presentation structure
+ * const result = client.verifyPresentation(vp);
+ * if (!result.valid) throw new Error(result.reason);
+ * ```
+ */
+export class PresentationClient {
+  /**
+   * Create a selective-disclosure Verifiable Presentation.
+   *
+   * Only the claim fields listed in `fieldsToDisclose` are included in the
+   * presentation's `credentialSubject`. The `claimsHash` from the on-chain
+   * record is always included so relying parties can verify the disclosed
+   * claims against the contract via `verify_claims_hash`.
+   *
+   * Claim fields not present in the credential are silently omitted.
+   *
+   * @param credential       Full on-chain credential from
+   *                         {@link CredentialClient.getCredential}.
+   * @param fieldsToDisclose Claim keys to include in the presentation.
+   * @param holderAddress    Optional Stellar address of the presenting party;
+   *                         becomes `did:stellar:<address>` in the `holder` field.
+   * @returns A {@link VerifiablePresentation} conforming to W3C VC DM 2.0.
+   *
+   * @example
+   * ```ts
+   * const vp = client.createPresentation(credential, ['name', 'country']);
+   * ```
+   */
+  createPresentation(
+    credential: Credential,
+    fieldsToDisclose: string[],
+    holderAddress?: string
+  ): VerifiablePresentation {
+    const disclosedClaims: Record<string, string> = {};
+    for (const field of fieldsToDisclose) {
+      if (Object.prototype.hasOwnProperty.call(credential.claims, field)) {
+        disclosedClaims[field] = credential.claims[field]!;
+      }
+    }
+
+    const presentationId = `urn:presentation:${randomBytes(16).toString('hex')}`;
+
+    const vc: VerifiableCredentialSubset = {
+      '@context': [W3C_VC_CONTEXT_V2],
+      type: ['VerifiableCredential'],
+      id: `urn:credential:${credential.id}`,
+      issuer: `did:stellar:${credential.issuer}`,
+      credentialSubject: {
+        id: `did:stellar:${credential.subject}`,
+        ...disclosedClaims,
+      },
+      credentialType: credential.credentialType,
+      claimsHash: credential.claimsHash,
+      issuedAt: credential.issuedAt,
+      expiresAt: credential.expiresAt,
+    };
+
+    return {
+      '@context': [W3C_VC_CONTEXT_V2],
+      type: ['VerifiablePresentation'],
+      id: presentationId,
+      holder: holderAddress ? `did:stellar:${holderAddress}` : undefined,
+      verifiableCredential: [vc],
+      created: Date.now(),
+    };
+  }
+
+  /**
+   * Verify the structural integrity of a Verifiable Presentation.
+   *
+   * Checks that the presentation conforms to W3C VC Data Model 2.0 and that
+   * every embedded credential subset contains the required fields for
+   * on-chain hash verification.
+   *
+   * **Note:** This method performs off-chain structural checks only. For full
+   * verification also call `CredentialClient.verifyCredential` with the
+   * credential ID and use the contract's `verify_claims_hash` entry point to
+   * confirm the disclosed claims match the on-chain hash.
+   *
+   * @param presentation The presentation to verify.
+   * @returns `{ valid: true }` when all structural checks pass; otherwise
+   *   `{ valid: false, reason }` identifying the first failing check.
+   *
+   * @example
+   * ```ts
+   * const result = client.verifyPresentation(vp);
+   * if (result.valid) {
+   *   // proceed to on-chain checks
+   * }
+   * ```
+   */
+  verifyPresentation(presentation: VerifiablePresentation): PresentationVerifyResult {
+    if (!Array.isArray(presentation['@context']) || !presentation['@context'].includes(W3C_VC_CONTEXT_V2)) {
+      return { valid: false, reason: 'INVALID_CONTEXT' };
+    }
+    if (!Array.isArray(presentation.type) || !presentation.type.includes('VerifiablePresentation')) {
+      return { valid: false, reason: 'INVALID_TYPE' };
+    }
+    if (!Array.isArray(presentation.verifiableCredential) || presentation.verifiableCredential.length === 0) {
+      return { valid: false, reason: 'MISSING_CREDENTIALS' };
+    }
+
+    for (const vc of presentation.verifiableCredential) {
+      if (!vc.id || !vc.issuer || !vc.claimsHash || !vc.credentialSubject?.id) {
+        return { valid: false, reason: 'INCOMPLETE_CREDENTIAL' };
+      }
+      const { id: _id, ...claims } = vc.credentialSubject;
+      if (Object.keys(claims).length === 0) {
+        return { valid: false, reason: 'MISSING_CLAIMS' };
+      }
+    }
+
+    return { valid: true };
+  }
+
+  /**
+   * Compute the SHA-256 hash of a set of disclosed claims.
+   *
+   * The hash is computed over the JSON-serialised `claims` object with keys
+   * sorted alphabetically. Relying parties can compare this value against the
+   * `claimsHash` stored on-chain via the contract's `verify_claims_hash`
+   * function to confirm the disclosed payload is genuine.
+   *
+   * @param disclosedClaims The `string → string` claims map to hash.
+   * @returns 64-character hex SHA-256 of the canonical JSON representation.
+   *
+   * @example
+   * ```ts
+   * const hash = client.computeDisclosedClaimsHash({ name: 'Alice', country: 'US' });
+   * // pass hash to CredentialClient.verifyClaimsHash() for on-chain confirmation
+   * ```
+   */
+  computeDisclosedClaimsHash(disclosedClaims: Record<string, string>): string {
+    const sorted = Object.fromEntries(
+      Object.entries(disclosedClaims).sort(([a], [b]) => a.localeCompare(b))
+    );
+    return createHash('sha256').update(JSON.stringify(sorted), 'utf8').digest('hex');
+  }
+}

--- a/sdk/src/request-queue.ts
+++ b/sdk/src/request-queue.ts
@@ -11,6 +11,14 @@ interface QueuedRequest<T> {
   maxRetries: number;
 }
 
+/**
+ * Concurrency-limited request queue with 429 / transient-error retry support.
+ *
+ * Wraps all outbound Soroban RPC calls so the SDK never fires more than
+ * `maxConcurrent` requests simultaneously. On `429 Too Many Requests` or
+ * connection errors the offending request is re-queued with exponential backoff
+ * up to `maxRetries` attempts.
+ */
 export class RequestQueue {
   private queue: QueuedRequest<any>[] = [];
   private activeRequests = 0;
@@ -18,11 +26,28 @@ export class RequestQueue {
   private readonly retryDelay: number;
   private processing = false;
 
+  /**
+   * @param maxConcurrent Maximum simultaneous in-flight requests. Defaults to `5`.
+   * @param retryDelay    Base retry delay in ms for 429 / transient errors.
+   *                      Defaults to `1000`.
+   */
   constructor(maxConcurrent = 5, retryDelay = 1000) {
     this.maxConcurrent = maxConcurrent;
     this.retryDelay = retryDelay;
   }
 
+  /**
+   * Enqueue an async function for rate-limited execution.
+   *
+   * The returned promise resolves (or rejects) once `fn` completes
+   * successfully or exhausts its retry budget.
+   *
+   * @param fn         Async function to execute.
+   * @param maxRetries Maximum retry attempts on 429 / transient errors.
+   *                   Defaults to `3`.
+   * @returns Promise that resolves with the return value of `fn`.
+   * @throws The last error thrown by `fn` after retries are exhausted.
+   */
   async enqueue<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       this.queue.push({

--- a/sdk/src/server/api-keys.ts
+++ b/sdk/src/server/api-keys.ts
@@ -33,6 +33,12 @@ export interface ApiKeyStore {
   touch(id: string, at: number): Promise<void>;
 }
 
+/**
+ * In-process {@link ApiKeyStore} backed by plain `Map`s.
+ *
+ * Suitable for single-process deployments and tests. Swap for a database-backed
+ * implementation in multi-node production environments.
+ */
 export class InMemoryApiKeyStore implements ApiKeyStore {
   private readonly byId = new Map<string, ApiKeyRecord>();
   private readonly byHash = new Map<string, string>();
@@ -71,6 +77,12 @@ export class InMemoryApiKeyStore implements ApiKeyStore {
   }
 }
 
+/**
+ * Compute the SHA-256 hex digest of a raw API key for at-rest storage.
+ *
+ * @param rawKey The plaintext key string as returned at issuance.
+ * @returns 64-character lowercase hex SHA-256 hash.
+ */
 export function hashApiKey(rawKey: string): string {
   return createHash("sha256").update(rawKey, "utf8").digest("hex");
 }
@@ -92,6 +104,26 @@ export interface IssueApiKeyOptions {
   idFn?: () => string;
 }
 
+/**
+ * Issue a new API key and persist it (hashed) in `store`.
+ *
+ * The raw key is returned ONCE and never stored. Callers must pass it to the
+ * API consumer immediately — it cannot be recovered.
+ *
+ * @param store   Backing store to persist the hashed record.
+ * @param options Owner, scope, and optional overrides for ID / clock / random source.
+ * @returns The raw key and its metadata.
+ * @throws {SorobanIdentityError} with code `ALREADY_EXISTS` if the generated
+ *   ID collides with an existing record.
+ *
+ * @example
+ * ```ts
+ * const { rawKey, metadata } = await issueApiKey(store, {
+ *   owner: 'alice',
+ *   scopes: ['read', 'write'],
+ * });
+ * ```
+ */
 export async function issueApiKey(
   store: ApiKeyStore,
   options: IssueApiKeyOptions,
@@ -115,6 +147,15 @@ export async function issueApiKey(
   };
 }
 
+/**
+ * Extract the bearer token from an `Authorization` header value.
+ *
+ * Returns `undefined` if the header is absent, malformed, or the token is
+ * empty after stripping the `Bearer ` prefix.
+ *
+ * @param header Raw `Authorization` header value (e.g. `"Bearer sk_abc123"`).
+ * @returns The raw API key string, or `undefined`.
+ */
 export function parseAuthorizationHeader(header: string | undefined): string | undefined {
   if (!header) return undefined;
   const trimmed = header.trim();
@@ -151,6 +192,22 @@ type ResLike = {
 };
 type NextLike = (err?: unknown) => void;
 
+/**
+ * Create an Express-compatible `Authorization: Bearer` authentication middleware.
+ *
+ * Validates the incoming API key against `options.store`, optionally enforces a
+ * required scope, touches `lastUsedAt`, and attaches `req.auth = { apiKey }`
+ * for downstream handlers.
+ *
+ * @param options Store, clock override, and optional required scope.
+ * @returns Async middleware function `(req, res, next) => void`.
+ * @throws Never — authentication failures are expressed as `401` JSON responses.
+ *
+ * @example
+ * ```ts
+ * app.use('/api/write', createApiKeyAuthMiddleware({ store, requireScope: 'write' }));
+ * ```
+ */
 export function createApiKeyAuthMiddleware(options: ApiKeyMiddlewareOptions) {
   const now = options.now ?? Date.now;
   return async function apiKeyAuth(req: ReqLike, res: ResLike, next: NextLike): Promise<void> {

--- a/sdk/src/server/rate-limit.ts
+++ b/sdk/src/server/rate-limit.ts
@@ -41,6 +41,13 @@ interface Bucket {
   config: RateLimitConfig;
 }
 
+/**
+ * Token-bucket rate limiter keyed by API key ID or remote IP.
+ *
+ * Tokens refill linearly over `windowMs`. Separate buckets are maintained for
+ * `read` and `write` rate classes. Per-key overrides can be supplied via
+ * {@link RateLimitOptions.overrides}.
+ */
 export class TokenBucketRateLimiter {
   private readonly buckets = new Map<string, Bucket>();
   private readonly now: () => number;
@@ -48,6 +55,9 @@ export class TokenBucketRateLimiter {
   private readonly readConfig: RateLimitConfig;
   private readonly writeConfig: RateLimitConfig;
 
+  /**
+   * @param options Rate limits, per-key overrides, and optional clock override.
+   */
   constructor(options: RateLimitOptions = {}) {
     this.now = options.now ?? Date.now;
     this.overrides = options.overrides ?? {};
@@ -120,6 +130,22 @@ function defaultClassify(_req: RequestLike, method: string): RateClass {
   return m === "GET" || m === "HEAD" || m === "OPTIONS" ? "read" : "write";
 }
 
+/**
+ * Create an Express-compatible rate-limit middleware backed by
+ * {@link TokenBucketRateLimiter}.
+ *
+ * Sets `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`
+ * headers on every response. Returns `429 Too Many Requests` with a
+ * `Retry-After` header when a bucket is exhausted.
+ *
+ * @param options Rate limit config, classifier, optional pre-built limiter.
+ * @returns Synchronous middleware function `(req, res, next) => void`.
+ *
+ * @example
+ * ```ts
+ * app.use(createRateLimitMiddleware({ read: { limit: 120, windowMs: 60_000 } }));
+ * ```
+ */
 export function createRateLimitMiddleware(options: RateLimitMiddlewareOptions = {}) {
   const limiter = options.rateLimiter ?? new TokenBucketRateLimiter(options);
   const keyFn = options.keyFn ?? defaultKey;

--- a/sdk/src/server/webhooks.ts
+++ b/sdk/src/server/webhooks.ts
@@ -34,6 +34,12 @@ export interface WebhookStore {
   forEvent(event: WebhookEvent): Promise<WebhookRegistration[]>;
 }
 
+/**
+ * In-process {@link WebhookStore} backed by a plain `Map`.
+ *
+ * Suitable for tests and single-process deployments. Replace with a
+ * persistent store in multi-node production environments.
+ */
 export class InMemoryWebhookStore implements WebhookStore {
   private readonly byId = new Map<string, WebhookRegistration>();
 
@@ -71,6 +77,29 @@ export interface RegisterWebhookOptions {
   now?: () => number;
 }
 
+/**
+ * Register a new webhook endpoint in `store`.
+ *
+ * Validates the URL scheme (must be `http` or `https`), secret length (≥ 16
+ * characters), and event list (must be a non-empty subset of
+ * {@link WEBHOOK_EVENTS}).
+ *
+ * @param store   Backing store to persist the registration.
+ * @param input   URL, secret, and event subscriptions for the new webhook.
+ * @param options Optional ID and clock overrides (useful for tests).
+ * @returns The persisted {@link WebhookRegistration}.
+ * @throws {SorobanIdentityError} with code `INVALID_INPUT` when validation
+ *   fails, or `ALREADY_EXISTS` on ID collision.
+ *
+ * @example
+ * ```ts
+ * const reg = await registerWebhook(store, {
+ *   url: 'https://example.com/hooks',
+ *   secret: 'my-secret-passphrase',
+ *   events: ['credential.issued'],
+ * });
+ * ```
+ */
 export async function registerWebhook(
   store: WebhookStore,
   input: RegisterWebhookInput,
@@ -137,10 +166,25 @@ const HEADER_SIGNATURE = "X-SorobanIdentity-Signature";
 const HEADER_EVENT = "X-SorobanIdentity-Event";
 const HEADER_ID = "X-SorobanIdentity-Delivery-Id";
 
+/**
+ * Compute the HMAC-SHA256 hex signature for a webhook payload.
+ *
+ * @param secret Webhook secret as provided at registration.
+ * @param body   JSON-serialised payload string to sign.
+ * @returns 64-character lowercase hex HMAC-SHA256 signature.
+ */
 export function signPayload(secret: string, body: string): string {
   return createHmac("sha256", secret).update(body, "utf8").digest("hex");
 }
 
+/**
+ * Verify a webhook payload signature using a timing-safe comparison.
+ *
+ * @param secret    Webhook secret used to sign the payload.
+ * @param body      Raw request body string received from the sender.
+ * @param signature Hex signature from the `X-SorobanIdentity-Signature` header.
+ * @returns `true` if the signature is valid; `false` otherwise.
+ */
 export function verifySignature(secret: string, body: string, signature: string): boolean {
   if (typeof signature !== "string") return false;
   const expected = signPayload(secret, body);
@@ -167,7 +211,25 @@ function backoffMs(attempt: number, base: number, max: number, jitter: number): 
   return Math.floor(grown * (1 + jitter));
 }
 
+/**
+ * Signs and delivers webhook payloads with exponential-backoff retry.
+ *
+ * Each delivery attempt POSTs a JSON body to the registered URL, signed with
+ * HMAC-SHA256 under the registration secret. Transient failures (5xx, 429,
+ * network errors) are retried up to `maxAttempts` times. Client errors (4xx
+ * except 429) fast-fail immediately.
+ *
+ * @example
+ * ```ts
+ * const dispatcher = new WebhookDispatcher({ maxAttempts: 3 });
+ * const result = await dispatcher.deliver(registration, 'credential.issued', payload);
+ * if (!result.ok) console.error('delivery failed', result.attempts);
+ * ```
+ */
 export class WebhookDispatcher {
+  /**
+   * @param options Retry budget, delay, sleep, fetch, and jitter overrides.
+   */
   constructor(private readonly options: DeliverOptions = {}) {}
 
   async deliver(

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -46,16 +46,31 @@ export interface Credential {
   revoked: boolean;
 }
 
-/** Reason a credential is invalid. Returned in {@link VerifyResult}. */
-export type VerifyFailReason = "not_found" | "revoked" | "expired" | "unknown";
+/**
+ * Reason a credential is invalid. Returned in {@link VerifyResult}.
+ *
+ * - `EXPIRED` — the credential's `expiresAt` timestamp has passed.
+ * - `REVOKED` — the issuer has explicitly revoked the credential.
+ * - `INVALID_SIGNATURE` — the stored issuer signature does not match.
+ * - `UNKNOWN_ISSUER` — no credential was found for the given ID, or the
+ *   credential's issuer is no longer registered.
+ * - `INACTIVE_SUBJECT` — the subject's DID has been deactivated.
+ */
+export type VerifyFailReason =
+  | 'EXPIRED'
+  | 'REVOKED'
+  | 'INVALID_SIGNATURE'
+  | 'UNKNOWN_ISSUER'
+  | 'INACTIVE_SUBJECT';
 
 /**
- * Discriminated result from {@link CredentialClient.verifyCredential}. Callers
- * can branch on the literal `valid` field with no parsing required.
+ * Result from {@link CredentialClient.verifyCredential}.
+ *
+ * `valid` is `true` when the credential is active and unexpired.
+ * `reason` is present when `valid` is `false` and a specific failure cause
+ * could be determined from the contract's typed error response.
  */
-export type VerifyResult =
-  | { valid: true }
-  | { valid: false; reason: VerifyFailReason };
+export type VerifyResult = { valid: boolean; reason?: VerifyFailReason };
 
 export interface SorobanIdentityLogger {
   debug(message: string, meta?: Record<string, unknown>): void;


### PR DESCRIPTION
## Summary

This PR resolves four SDK/contract issues in a single branch:

### Closes #311 — Typed `verifyCredential` result with failure reason
- Contract `verify_credential` return type changed from `bool` → `Result<(), ContractError>`, returning `CredentialNotFound`, `CredentialRevoked`, or `CredentialExpired` as typed errors instead of an opaque `false`.
- `VerifyFailReason` updated to the W3C-aligned set: `EXPIRED | REVOKED | INVALID_SIGNATURE | UNKNOWN_ISSUER | INACTIVE_SUBJECT`.
- `VerifyResult` simplified to `{ valid: boolean; reason?: VerifyFailReason }`.
- `verifyCredential` in the SDK now maps contract error codes to reasons directly — no secondary `getCredential` fetch needed.
- All affected contract tests updated to use the `try_verify_credential` / `Err(Ok(ContractError::X))` pattern.

### Closes #314 — Issuer-indexed credential storage + `getCredentialsByIssuer`
- New `ISSCREDS` storage key maintains a `Vec<BytesN<32>>` per issuer, updated on every `issue_credential` call.
- New contract functions: `get_issuer_credentials(issuer)` (unbounded) and `list_issuer_credentials(issuer, cursor, limit)` (cursor-paginated, capped at `PAGE_CAP`).
- SDK adds `getCredentialsByIssuer` and `listCredentialsByIssuer` to `CredentialClient`.
- New `buildGetIssuerCredentialsArgs` and `buildListIssuerCredentialsArgs` arg builders exported from the package root.

### Closes #313 — `PresentationClient` for W3C VC 2.0 selective disclosure
- New `sdk/src/presentation.ts` exports `PresentationClient` with three methods:
  - `createPresentation(credential, fieldsToDisclose, holderAddress?)` — returns a W3C VC DM 2.0 `VerifiablePresentation` containing only the chosen claim fields alongside the on-chain `claimsHash`.
  - `verifyPresentation(presentation)` — structural validation (context, type, required fields). Returns `PresentationVerifyResult`.
  - `computeDisclosedClaimsHash(claims)` — SHA-256 of the canonical JSON for on-chain `verify_claims_hash` comparison.
- All types (`VerifiablePresentation`, `VerifiableCredentialSubset`, `PresentationProof`, etc.) exported from the package root.

### Closes #312 — JSDoc on all public SDK methods
- `contract-args.ts`: every builder function now has `@param` and `@returns` tags describing the target contract call.
- `base-client.ts`: class overview, constructor, and `executeWithFailover` documented.
- `request-queue.ts`: `RequestQueue` class, constructor, and `enqueue` fully documented.
- `events.ts`: interface field JSDoc; `SorobanEventListener` class and constructor; `@example` on `getEvents`.
- `server/api-keys.ts`: `InMemoryApiKeyStore`, `hashApiKey`, `issueApiKey`, `parseAuthorizationHeader`, `createApiKeyAuthMiddleware` — `@param / @returns / @throws / @example`.
- `server/rate-limit.ts`: `TokenBucketRateLimiter`, `createRateLimitMiddleware` documented.
- `server/webhooks.ts`: `InMemoryWebhookStore`, `WebhookDispatcher`, `registerWebhook`, `signPayload`, `verifySignature` documented.

## Test plan
- [ ] Rust contract tests pass: `cargo test -p credential-manager`
- [ ] TypeScript SDK compiles: `cd sdk && npx tsc --noEmit`
- [ ] Verify `getCredentialsByIssuer` returns credentials indexed by issuer address after issuance
- [ ] Verify `verifyCredential` returns `{ valid: false, reason: 'REVOKED' }` for a revoked credential
- [ ] Verify `PresentationClient.createPresentation` excludes non-listed claim fields
- [ ] Verify `PresentationClient.verifyPresentation` rejects malformed presentations

🤖 Generated with [Claude Code](https://claude.com/claude-code)