### PR TITLE
fix: resolve issues #291, #292, #293, #294

### DIFF
--- a/frontend/src/components/WalletButton.tsx
+++ b/frontend/src/components/WalletButton.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
-import type { WalletState, WalletType } from "../hooks/useWallet";
+import type { WalletType } from "../hooks/useWallet";
 import { useWalletContext } from "../context/WalletContext";
 
 export default function WalletButton() {
-  const wallet = useWalletContext();
+  const { connected, publicKey, connecting, txLoading, error, walletType, connect, disconnect } = useWalletContext();
   const [showPicker, setShowPicker] = useState(false);
 
   const short = (key: string) => `${key.slice(0, 4)}…${key.slice(-4)}`;
@@ -78,14 +78,17 @@ export default function WalletButton() {
 
       {error && (
         <span style={{ fontSize: "0.75rem", color: "var(--error-text)" }}>
-          {error.toLowerCase().includes("freighter not found") ? (
-            <>Freighter not installed.{" "}
-              <a href="https://freighter.app" target="_blank" rel="noopener noreferrer"
-                style={{ color: "var(--accent-light)", textDecoration: "underline" }}>
-                Install it here
-              </a>
-            </>
-          ) : error}
+          {(() => {
+            const msg = error instanceof Error ? error.message : typeof error === "string" && error ? error : "Wallet connection failed. Please try again.";
+            return msg.toLowerCase().includes("freighter not found") ? (
+              <>Freighter not installed.{" "}
+                <a href="https://freighter.app" target="_blank" rel="noopener noreferrer"
+                  style={{ color: "var(--accent-light)", textDecoration: "underline" }}>
+                  Install it here
+                </a>
+              </>
+            ) : msg;
+          })()}
         </span>
       )}
     </div>

--- a/package.json
+++ b/package.json
@@ -4,5 +4,10 @@
   "workspaces": [
     "sdk",
     "frontend"
-  ]
+  ],
+  "scripts": {
+    "build": "npm run build --workspace=sdk && npm run build --workspace=frontend",
+    "build:sdk": "npm run build --workspace=sdk",
+    "build:frontend": "npm run build --workspace=frontend"
+  }
 }

--- a/sdk/src/contract-args.ts
+++ b/sdk/src/contract-args.ts
@@ -61,7 +61,7 @@ export function buildIssueCredentialArgs(params: {
   claims: Record<string, string>;
   claimsHash: Buffer;
   signature: Buffer;
-  expiresAt: number;
+  expiresAt: bigint;
 }): xdr.ScVal[] {
   return [
     nativeToScVal(params.issuer, { type: 'address' }),
@@ -70,7 +70,7 @@ export function buildIssueCredentialArgs(params: {
     nativeToScVal(params.claims, { type: 'map' }),
     nativeToScVal(params.claimsHash, { type: 'bytes' }),
     nativeToScVal(params.signature, { type: 'bytes' }),
-    nativeToScVal(params.expiresAt, { type: 'u64' }),
+    xdr.ScVal.scvU64(xdr.Uint64.fromString(params.expiresAt.toString())),
   ];
 }
 
@@ -158,12 +158,12 @@ export function buildPassesSybilCheckDefaultArgs(params: {
 
 export function buildPassesSybilCheckArgs(params: {
   subject: string;
-  minScore: number;
+  minScore: bigint;
   minReporters: number;
 }): xdr.ScVal[] {
   return [
     nativeToScVal(params.subject, { type: 'address' }),
-    nativeToScVal(params.minScore, { type: 'i64' }),
+    xdr.ScVal.scvI64(xdr.Int64.fromString(params.minScore.toString())),
     nativeToScVal(params.minReporters, { type: 'u32' }),
   ];
 }
@@ -171,13 +171,13 @@ export function buildPassesSybilCheckArgs(params: {
 export function buildSubmitScoreArgs(params: {
   reporter: string;
   subject: string;
-  delta: number;
+  delta: bigint;
   reason: string;
 }): xdr.ScVal[] {
   return [
     nativeToScVal(params.reporter, { type: 'address' }),
     nativeToScVal(params.subject, { type: 'address' }),
-    nativeToScVal(params.delta, { type: 'i64' }),
+    xdr.ScVal.scvI64(xdr.Int64.fromString(params.delta.toString())),
     nativeToScVal(params.reason, { type: 'string' }),
   ];
 }

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -182,7 +182,7 @@ export class CredentialClient extends BaseClient {
             claims,
             claimsHash: Buffer.from(claimsHashHex, "hex"),
             signature: Buffer.from(signature),
-            expiresAt,
+            expiresAt: BigInt(expiresAt),
           })
         )
       )

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -72,6 +72,7 @@ export class ReputationClient extends BaseClient {
    * @param config SDK config including the deployed reputation contract ID.
    */
   constructor(config: SorobanIdentityConfig) {
+    validateConfig(config, { contractIdField: 'reputationId' });
     super(config, config.reputationId);
   }
 
@@ -369,7 +370,7 @@ export class ReputationClient extends BaseClient {
       .addOperation(
         this.contract.call(
           'passes_sybil_check',
-          ...buildPassesSybilCheckArgs({ subject: subjectAddress, minScore, minReporters })
+          ...buildPassesSybilCheckArgs({ subject: subjectAddress, minScore: BigInt(minScore), minReporters })
         )
       )
       .setTimeout(timeout)
@@ -420,7 +421,7 @@ export class ReputationClient extends BaseClient {
       ...buildSubmitScoreArgs({
         reporter: reporterKeypair.publicKey(),
         subject: subjectAddress,
-        delta,
+        delta: BigInt(delta),
         reason,
       })
     );


### PR DESCRIPTION
## Summary

Fixes four assigned bugs in one commit.

### #291 — Build ordering
Added `build`, `build:sdk`, and `build:frontend` scripts to root `package.json` so `npm run build` always compiles the SDK before the frontend, preventing `Module not found` errors for first-time contributors.

### #292 — WalletButton error display
Destructured wallet context fields (`connected`, `publicKey`, `connecting`, `txLoading`, `error`, `walletType`, `connect`, `disconnect`) from `useWalletContext()`. Error display now uses `error instanceof Error ? error.message : typeof error === 'string' && error ? error : 'Wallet connection failed. Please try again.'` with a generic fallback instead of calling `.toString()` on a raw object.

### #293 — Contract ID validation
Added `validateConfig(config, { contractIdField: 'reputationId' })` to `ReputationClient`'s constructor so invalid contract IDs fail fast with a descriptive error at startup rather than an opaque RPC failure.

### #294 — BigInt for i64/u64
Changed `buildIssueCredentialArgs`, `buildPassesSybilCheckArgs`, and `buildSubmitScoreArgs` to accept `bigint` for `expiresAt`, `minScore`, and `delta` respectively, using `xdr.ScVal.scvU64(xdr.Uint64.fromString(...))` / `xdr.ScVal.scvI64(xdr.Int64.fromString(...))` to avoid JavaScript number precision loss on large i64/u64 values. Call sites in `reputation.ts` and `credentials.ts` updated to pass `BigInt(value)`.

Closes #291
Closes #292
Closes #293
Closes #294