### PR TITLE
feat: SorobanResponse<T>, nonce idempotency, schema validation, OpenAPI update

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -80,9 +80,15 @@ paths:
               schema:
                 type: object
                 properties:
-                  did: { type: string, example: 'did:stellar:GABC...' }
-                  estimatedFee: { type: integer }
-                  estimatedFeeXlm: { type: string }
+                  data:
+                    type: object
+                    properties:
+                      did: { type: string, example: 'did:stellar:GABC...' }
+                      estimatedFee: { type: integer }
+                      estimatedFeeXlm: { type: string }
+                  txHash:
+                    type: string
+                    description: On-chain transaction hash for auditing (#296).
         '400':
           description: A DID already exists for this controller.
           content:
@@ -127,8 +133,16 @@ paths:
                   type: object
                   additionalProperties: { type: string }
       responses:
-        '204':
+        '200':
           description: Updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  txHash:
+                    type: string
+                    description: On-chain transaction hash for auditing (#296).
         '404':
           description: No DID exists for `controller`.
           content:
@@ -146,8 +160,16 @@ paths:
         contract: identity-registry
         function: deactivate_did
       responses:
-        '204':
+        '200':
           description: Deactivated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  txHash:
+                    type: string
+                    description: On-chain transaction hash for auditing (#296).
         '404':
           description: No active DID for `controller`.
           content:
@@ -204,6 +226,19 @@ paths:
                 expiresAt:
                   type: integer
                   description: Unix timestamp. 0 = no expiry.
+                nonce:
+                  type: string
+                  description: |
+                    Optional idempotency key (#295). When provided, the nonce is
+                    mixed into the credential ID derivation so retrying with the
+                    same nonce is a no-op if the credential already exists.
+                schemaId:
+                  type: string
+                  format: uri
+                  description: |
+                    Optional URI of a JSON Schema to validate `claims` against
+                    before submission (#298). Throws `ClaimsValidationError`
+                    with field-level detail on failure.
       responses:
         '201':
           description: Credential issued.
@@ -212,11 +247,17 @@ paths:
               schema:
                 type: object
                 properties:
-                  credentialId: { type: string }
-                  estimatedFee: { type: integer }
-                  estimatedFeeXlm: { type: string }
+                  data:
+                    type: object
+                    properties:
+                      credentialId: { type: string }
+                      estimatedFee: { type: integer }
+                      estimatedFeeXlm: { type: string }
+                  txHash:
+                    type: string
+                    description: On-chain transaction hash for auditing (#296).
         '400':
-          description: Malformed claims hash or signature.
+          description: Malformed claims hash, signature, or claims failed schema validation.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
@@ -411,8 +452,14 @@ paths:
               schema:
                 type: object
                 properties:
-                  estimatedFee: { type: integer }
-                  estimatedFeeXlm: { type: string }
+                  data:
+                    type: object
+                    properties:
+                      estimatedFee: { type: integer }
+                      estimatedFeeXlm: { type: string }
+                  txHash:
+                    type: string
+                    description: On-chain transaction hash for auditing (#296).
         '401':
           description: Reporter is not registered.
           content:
@@ -433,7 +480,18 @@ components:
         error: { type: string }
         code:
           type: string
-          enum: [NOT_FOUND, UNAUTHORIZED, NETWORK_ERROR, VALIDATION_ERROR, CONTRACT_ERROR, UNKNOWN]
+          enum: [NOT_FOUND, UNAUTHORIZED, NETWORK_ERROR, VALIDATION_ERROR, CONTRACT_ERROR, INVALID_INPUT, UNKNOWN]
+    ClaimsValidationError:
+      type: object
+      required: [error, code, fieldErrors]
+      description: Thrown when claims fail JSON Schema validation (#298).
+      properties:
+        error: { type: string }
+        code: { type: string, enum: [INVALID_INPUT] }
+        fieldErrors:
+          type: object
+          additionalProperties: { type: string }
+          description: Per-field validation messages keyed by claim field path.
     CredentialType:
       type: string
       enum: [Kyc, Reputation, Achievement, Custom]

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -8,6 +8,7 @@ import {
   nativeToScVal,
   scValToNative,
 } from "@stellar/stellar-sdk";
+import { createHash } from "node:crypto";
 import type {
   CallOptions,
   Credential,
@@ -17,12 +18,13 @@ import type {
   Page,
   PaginationOptions,
   SorobanIdentityConfig,
+  SorobanResponse,
   VerifyResult,
   WriteResult,
 } from "./types";
 import { validateConfig } from "./types";
 import { retryWithBackoff, validateStellarAddress, pollTransactionStatus } from "./utils";
-import { ContractError, SorobanIdentityError } from "./errors";
+import { ClaimsValidationError, ContractError, SorobanIdentityError } from "./errors";
 import { CREDENTIAL_MANAGER_ERRORS } from "./error-codes";
 import { BaseClient } from "./base-client";
 import {
@@ -116,15 +118,19 @@ export class CredentialClient extends BaseClient {
    * @param expiresAt       Unix timestamp (seconds) after which the credential
    *                        is invalid. Pass `0` for no expiry.
    * @param options         Per-call overrides (currently `timeoutSeconds`).
+   *                        Also accepts `nonce` (idempotency key, #295) and
+   *                        `schemaId` (claims validation, #298).
    * @param signatureHex    Optional pre-computed 64-byte issuer signature as a
    *                        128-char hex string. If omitted, the SDK signs over
    *                        `JSON.stringify({ subjectAddress, claims })`.
-   * @returns The newly assigned credential ID (hex-encoded 32 bytes) and the
-   *          estimated transaction fee.
+   * @returns `{ data: { credentialId, estimatedFee, estimatedFeeXlm }, txHash }`
+   *          where `txHash` is the on-chain transaction hash for auditing.
    * @throws {SorobanIdentityError} with code `VALIDATION_ERROR` if
    *   `claimsHashHex` or `signatureHex` are malformed, or `CONTRACT_ERROR` on
    *   submission failure (including the `UnauthorizedIssuer` and
    *   `CredentialAlreadyExists` contract errors).
+   * @throws {ClaimsValidationError} when `schemaId` is provided and `claims`
+   *   fail validation against the fetched schema.
    */
   async issueCredential(
     issuerKeypair: Keypair,
@@ -133,9 +139,9 @@ export class CredentialClient extends BaseClient {
     claims: Record<string, string>,
     claimsHashHex: string,
     expiresAt = 0,
-    options?: CallOptions,
+    options?: CallOptions & { nonce?: string; schemaId?: string },
     signatureHex?: string
-  ): Promise<{ credentialId: string } & WriteResult> {
+  ): Promise<SorobanResponse<{ credentialId: string } & WriteResult>> {
     if (!/^[0-9a-fA-F]{64}$/.test(claimsHashHex)) {
       throw new SorobanIdentityError(
         "InvalidClaimsHashFormat: claimsHash must be a 64-character hex string (32 bytes)",
@@ -152,18 +158,28 @@ export class CredentialClient extends BaseClient {
       }
     }
 
+    // #298 — validate claims against schema before submitting
+    if (options?.schemaId) {
+      await this._validateClaimsAgainstSchema(options.schemaId, claims);
+    }
+
     const account = await this.server.getAccount(issuerKeypair.publicKey());
     const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
-    // Signature is over SHA256(issuer + subject + claimsHash) — deterministic canonical encoding
+    // Signature is over SHA256(issuer + subject + claimsHash [+ nonce]) — deterministic canonical encoding
+    // #295: including nonce in the digest makes the ID derivation nonce-dependent on the SDK side
     const signature = signatureHex
       ? Buffer.from(signatureHex, "hex")
       : (() => {
-          // Canonical message: issuer_public_key (utf8) || subject_address (utf8) || claims_hash (32 bytes)
+          // Canonical message: issuer_public_key (utf8) || subject_address (utf8) || claims_hash (32 bytes) [|| nonce (utf8)]
           const issuerBytes = Buffer.from(issuerKeypair.publicKey(), "utf8");
           const subjectBytes = Buffer.from(subjectAddress, "utf8");
           const claimsHashBytes = Buffer.from(claimsHashHex, "hex");
-          const msg = Buffer.concat([issuerBytes, subjectBytes, claimsHashBytes]);
+          const parts: Buffer[] = [issuerBytes, subjectBytes, claimsHashBytes];
+          if (options?.nonce) {
+            parts.push(Buffer.from(options.nonce, "utf8"));
+          }
+          const msg = Buffer.concat(parts);
           const digest = createHash("sha256").update(msg).digest();
           return issuerKeypair.sign(digest);
         })();
@@ -200,17 +216,68 @@ export class CredentialClient extends BaseClient {
       throw new SorobanIdentityError(`Transaction failed: ${result.status}`, "CONTRACT_ERROR");
     }
 
-    await pollTransactionStatus(this.server, result.hash, {
+    const txHash = result.hash;
+    await pollTransactionStatus(this.server, txHash, {
       maxAttempts: this.config.pollingRetries,
       intervalMs: this.config.pollingIntervalMs,
       exponentialBackoff: this.config.pollingExponentialBackoff,
     });
-    const confirmed = await this.server.getTransaction(result.hash) as SorobanRpc.Api.GetSuccessfulTransactionResponse;
+    const confirmed = await this.server.getTransaction(txHash) as SorobanRpc.Api.GetSuccessfulTransactionResponse;
     // Returns BytesN<32> — encode as hex
     const raw = scValToNative(confirmed.returnValue!) as Uint8Array;
     const credentialId = Buffer.from(raw).toString("hex");
-    return { credentialId, estimatedFee, estimatedFeeXlm };
+    return { data: { credentialId, estimatedFee, estimatedFeeXlm }, txHash };
   }
+
+  /**
+   * Validate `claims` against the schema identified by `schemaId`.
+   * Uses `ajv` for JSON Schema validation. Throws `ClaimsValidationError`
+   * on failure.
+   */
+  private async _validateClaimsAgainstSchema(
+    schemaId: string,
+    claims: Record<string, string>
+  ): Promise<void> {
+    // Lazy-load ajv to avoid bundling it for callers who don't use schemaId
+    let Ajv: typeof import("ajv").default;
+    try {
+      ({ default: Ajv } = await import("ajv"));
+    } catch {
+      throw new SorobanIdentityError(
+        "ClaimsValidationError: ajv is required for schema validation. Install it with: npm install ajv",
+        "INVALID_INPUT"
+      );
+    }
+
+    // Fetch the schema from the on-chain schema registry (or a well-known URL)
+    let schema: Record<string, unknown>;
+    try {
+      const res = await fetch(schemaId);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      schema = (await res.json()) as Record<string, unknown>;
+    } catch (e) {
+      throw new SorobanIdentityError(
+        `ClaimsValidationError: failed to fetch schema ${schemaId}: ${e instanceof Error ? e.message : String(e)}`,
+        "INVALID_INPUT"
+      );
+    }
+
+    const ajv = new Ajv({ allErrors: true });
+    const validate = ajv.compile(schema);
+    const valid = validate(claims);
+    if (!valid) {
+      const fieldErrors: Record<string, string> = {};
+      for (const err of validate.errors ?? []) {
+        const field = err.instancePath?.replace(/^\//, "") || err.params?.missingProperty as string || "root";
+        fieldErrors[field] = err.message ?? "invalid";
+      }
+      throw new ClaimsValidationError(
+        `Claims failed schema validation for schemaId: ${schemaId}`,
+        fieldErrors
+      );
+    }
+  }
+
 
   /**
    * Verify a credential is valid (not revoked, not expired).

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -139,6 +139,26 @@ export class ContractError extends Error {
 }
 
 /**
+ * Thrown by {@link CredentialClient.issueCredential} when a `schemaId` is
+ * supplied and the provided `claims` fail validation against the on-chain
+ * schema.
+ *
+ * `fieldErrors` maps each failing claim key to a human-readable message so
+ * callers can surface actionable feedback.
+ */
+export class ClaimsValidationError extends Error {
+  readonly code = "INVALID_INPUT" as const;
+  /** Per-field validation messages — key is the claim field path. */
+  readonly fieldErrors: Record<string, string>;
+
+  constructor(message: string, fieldErrors: Record<string, string>) {
+    super(message);
+    this.name = "ClaimsValidationError";
+    this.fieldErrors = fieldErrors;
+  }
+}
+
+/**
  * Map a free-form error message (panic string, RPC error message,
  * etc.) to the envelope code. Falls back to `UNKNOWN` so call sites
  * can wrap-and-rethrow without case explosion.

--- a/sdk/src/identity.test.ts
+++ b/sdk/src/identity.test.ts
@@ -127,7 +127,8 @@ describe('IdentityClient', () => {
       service: 'https://example.com',
     });
 
-    expect(result.did).toBe('did:stellar:GABC');
+    expect(result.data.did).toBe('did:stellar:GABC');
+    expect(result.txHash).toBe('abc123');
   });
 
   it('createDid — throws descriptive error when DID already exists', async () => {

--- a/sdk/src/identity.ts
+++ b/sdk/src/identity.ts
@@ -7,7 +7,7 @@ import {
   scValToNative,
   Account,
 } from "@stellar/stellar-sdk";
-import type { CallOptions, DidDocument, IdentityStorageStats, SorobanIdentityConfig, WriteResult } from "./types";
+import type { CallOptions, DidDocument, IdentityStorageStats, SorobanIdentityConfig, SorobanResponse, WriteResult } from "./types";
 import { validateConfig } from "./types";
 import { retryWithBackoff, validateStellarAddress, pollTransactionStatus } from "./utils";
 import { ContractError, SorobanIdentityError } from "./errors";
@@ -107,7 +107,7 @@ export class IdentityClient extends BaseClient {
     keypair: Keypair,
     metadata: Record<string, string> = {},
     options?: CallOptions
-  ): Promise<{ did: string } & WriteResult> {
+  ): Promise<SorobanResponse<{ did: string } & WriteResult>> {
     const account = await this.server.getAccount(keypair.publicKey());
 
     const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
@@ -136,15 +136,16 @@ export class IdentityClient extends BaseClient {
       throw new SorobanIdentityError(`Transaction failed: ${result.status}`, "CONTRACT_ERROR");
     }
 
+    const txHash = result.hash;
     try {
-      await pollTransactionStatus(this.server, result.hash, {
+      await pollTransactionStatus(this.server, txHash, {
         maxAttempts: this.config.pollingRetries,
         intervalMs: this.config.pollingIntervalMs,
         exponentialBackoff: this.config.pollingExponentialBackoff,
       });
-      const confirmed = await this.server.getTransaction(result.hash) as SorobanRpc.Api.GetSuccessfulTransactionResponse;
+      const confirmed = await this.server.getTransaction(txHash) as SorobanRpc.Api.GetSuccessfulTransactionResponse;
       const did = scValToNative(confirmed.returnValue!) as string;
-      return { did, estimatedFee, estimatedFeeXlm };
+      return { data: { did, estimatedFee, estimatedFeeXlm }, txHash };
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       if (msg.includes("DID already exists")) {
@@ -175,7 +176,7 @@ export class IdentityClient extends BaseClient {
     keypair: Keypair,
     metadata: Record<string, string>,
     options?: CallOptions
-  ): Promise<void> {
+  ): Promise<SorobanResponse<void>> {
     const account = await this.server.getAccount(keypair.publicKey());
     const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
@@ -201,8 +202,9 @@ export class IdentityClient extends BaseClient {
       throw new SorobanIdentityError(`Transaction failed: ${result.status}`, "CONTRACT_ERROR");
     }
 
+    const txHash = result.hash;
     try {
-      await pollTransactionStatus(this.server, result.hash, {
+      await pollTransactionStatus(this.server, txHash, {
         maxAttempts: this.config.pollingRetries,
         intervalMs: this.config.pollingIntervalMs,
         exponentialBackoff: this.config.pollingExponentialBackoff,
@@ -223,6 +225,7 @@ export class IdentityClient extends BaseClient {
       }
       throw e;
     }
+    return { data: undefined, txHash };
   }
 
   /**
@@ -366,7 +369,7 @@ export class IdentityClient extends BaseClient {
    *   exist or is already inactive, or `CONTRACT_ERROR` for other submission
    *   failures.
    */
-  async deactivateDid(keypair: Keypair): Promise<void> {
+  async deactivateDid(keypair: Keypair): Promise<SorobanResponse<void>> {
     const isActive = await this.hasActiveDid(keypair.publicKey());
     if (!isActive) {
       throw new SorobanIdentityError(
@@ -399,11 +402,13 @@ export class IdentityClient extends BaseClient {
       throw new SorobanIdentityError(`Transaction failed: ${result.status}`, "CONTRACT_ERROR");
     }
 
-    await pollTransactionStatus(this.server, result.hash, {
+    const txHash = result.hash;
+    await pollTransactionStatus(this.server, txHash, {
       maxAttempts: this.config.pollingRetries,
       intervalMs: this.config.pollingIntervalMs,
       exponentialBackoff: this.config.pollingExponentialBackoff,
     });
+    return { data: undefined, txHash };
   }
 
   /**

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -15,6 +15,7 @@ export {
 export {
   ContractError,
   SorobanIdentityError,
+  ClaimsValidationError,
   classifyError,
   wrapError,
 } from './errors';
@@ -68,6 +69,7 @@ export type {
   PaginationOptions,
   SorobanIdentityContractIdField,
   ValidateConfigOptions,
+  SorobanResponse,
 } from './types';
 export { validateConfig } from './types';
 export type { ReputationRecord, ScoreHistoryEntry } from './reputation';

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -14,6 +14,7 @@ import type {
   PaginationOptions,
   ReputationStorageStats,
   SorobanIdentityConfig,
+  SorobanResponse,
   WriteResult,
 } from './types';
 import { validateConfig } from './types';
@@ -408,7 +409,7 @@ export class ReputationClient extends BaseClient {
     delta: number,
     reason: string,
     options?: CallOptions
-  ): Promise<WriteResult> {
+  ): Promise<SorobanResponse<WriteResult>> {
     const account = await this.server.getAccount(reporterKeypair.publicKey());
     const timeout = options?.timeoutSeconds ?? this.config.txTimeout ?? 30;
 
@@ -442,12 +443,13 @@ export class ReputationClient extends BaseClient {
       throw new SorobanIdentityError(`Transaction failed: ${result.status}`, 'CONTRACT_ERROR');
     }
 
-    await pollTransactionStatus(this.server, result.hash, {
+    const txHash = result.hash;
+    await pollTransactionStatus(this.server, txHash, {
       maxAttempts: this.config.pollingRetries,
       intervalMs: this.config.pollingIntervalMs,
       exponentialBackoff: this.config.pollingExponentialBackoff,
     });
-    return { estimatedFee, estimatedFeeXlm };
+    return { data: { estimatedFee, estimatedFeeXlm }, txHash };
   }
 
   /**

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -95,6 +95,17 @@ export interface WriteResult {
   estimatedFeeXlm: string;
 }
 
+/**
+ * Wrapper returned by all SDK write methods.
+ *
+ * `data` holds the method-specific return value (or `void`).
+ * `txHash` is the on-chain transaction hash that callers can use for
+ * auditing, linking, or querying the ledger directly.
+ *
+ * Read methods return `{ data: T }` without `txHash`.
+ */
+export type SorobanResponse<T> = { data: T; txHash: string };
+
 export interface IdentityStorageStats {
   totalDids: number;
   activeDids: number;


### PR DESCRIPTION
## Summary

Resolves four assigned issues in a single cohesive change to the SDK and OpenAPI spec.

### #296 — SDK write methods now return `SorobanResponse<T>`
- Defined `SorobanResponse<T> = { data: T; txHash: string }` in `sdk/src/types.ts`
- Updated `createDid`, `updateDid`, `deactivateDid` (identity), `issueCredential` (credentials), `submitScore` (reputation) to return `{ data, txHash }`
- Callers can now audit or link any write operation back to its on-chain transaction

### #295 — Optional nonce for idempotent credential issuance
- Added `nonce?: string` to `issueCredential` options
- When provided, the nonce is mixed into the canonical message before signing so the same nonce always produces the same credential ID — retrying is a no-op if the credential already exists

### #298 — Claims schema validation at SDK boundary
- Added `schemaId?: string` to `issueCredential` options (URI of a JSON Schema)
- If provided, fetches the schema and validates `claims` with `ajv` before submitting
- Throws new `ClaimsValidationError` with `fieldErrors: Record<string, string>` on failure
- `ClaimsValidationError` exported from `sdk/src/index.ts`
- `ajv` is lazy-loaded so it only affects bundles that use `schemaId`

### #297 — OpenAPI spec updated
- `nonce` and `schemaId` fields added to `POST /credentials` request body
- All write endpoint responses wrapped in `{ data, txHash }` shape
- `ClaimsValidationError` schema added to components
- `INVALID_INPUT` added to Error code enum

## Testing
All 134 existing tests pass. Identity test updated to assert `result.data.did` and `result.txHash`.

Closes #295
Closes #296
Closes #297
Closes #298