### PR TITLE
Fix wallet reconnect button state

### DIFF
--- a/frontend/src/components/WalletButton.tsx
+++ b/frontend/src/components/WalletButton.tsx
@@ -3,15 +3,18 @@ import type { WalletType } from "../hooks/useWallet";
 import { useWalletContext } from "../context/WalletContext";
 
 export default function WalletButton() {
-  const { connected, publicKey, connecting, txLoading, error, walletType, connect, disconnect } = useWalletContext();
+  const { connected, publicKey, connecting, reconnecting, txLoading, error, walletType, connect, disconnect } = useWalletContext();
   const [showPicker, setShowPicker] = useState(false);
 
   const short = (key: string) => `${key.slice(0, 4)}…${key.slice(-4)}`;
 
   const handleSelect = (type: WalletType) => {
+    if (connecting || reconnecting) return;
     setShowPicker(false);
     connect(type);
   };
+
+  const walletActionDisabled = connecting || reconnecting;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: "0.25rem", position: "relative" }}>
@@ -39,12 +42,12 @@ export default function WalletButton() {
         <>
           <button
             onClick={() => setShowPicker((v) => !v)}
-            disabled={connecting}
+            disabled={walletActionDisabled}
           >
-            {connecting ? "Connecting…" : "Connect Wallet"}
+            {reconnecting ? "Reconnecting…" : connecting ? "Connecting…" : "Connect Wallet"}
           </button>
 
-          {showPicker && (
+          {showPicker && !walletActionDisabled && (
             <div style={{
               position: "absolute",
               top: "calc(100% + 0.5rem)",
@@ -79,7 +82,7 @@ export default function WalletButton() {
       {error && (
         <span style={{ fontSize: "0.75rem", color: "var(--error-text)" }}>
           {(() => {
-            const msg = error instanceof Error ? error.message : typeof error === "string" && error ? error : "Wallet connection failed. Please try again.";
+            const msg = error || "Wallet connection failed. Please try again.";
             return msg.toLowerCase().includes("freighter not found") ? (
               <>Freighter not installed.{" "}
                 <a href="https://freighter.app" target="_blank" rel="noopener noreferrer"

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -1,12 +1,13 @@
 import { createContext, useContext, type ReactNode } from "react";
 import { useWallet } from "../hooks/useWallet";
+import type { WalletType } from "../hooks/useWallet";
 import type { WalletState } from "../hooks/useWalletState";
 import type { FrontendNetworkConfig } from "../network";
 import { getNetworkConfig } from "../network";
 
 interface WalletContextValue extends WalletState {
-  connect: (walletType?: string) => void;
-  disconnect: () => void;
+  connect: (walletType?: WalletType) => Promise<void>;
+  disconnect: () => Promise<void>;
   signTransaction: (xdr: string) => Promise<string>;
 }
 

--- a/frontend/src/hooks/useFreighterAccountSync.ts
+++ b/frontend/src/hooks/useFreighterAccountSync.ts
@@ -30,6 +30,7 @@ export function useFreighterAccountSync({
             networkPassphrase,
             connected: true,
             connecting: false,
+            reconnecting: false,
             walletType: "freighter",
             txLoading: false,
             error: null,

--- a/frontend/src/hooks/useWalletConnection.ts
+++ b/frontend/src/hooks/useWalletConnection.ts
@@ -36,6 +36,7 @@ export function useWalletConnection({
       setState((s) => ({
         ...s,
         connecting: false,
+        reconnecting: false,
         error: "Freighter not found. Install it from freighter.app",
       }));
       return;
@@ -47,6 +48,7 @@ export function useWalletConnection({
         setState((s) => ({
           ...s,
           connecting: false,
+          reconnecting: false,
           error: "Please unlock Freighter and try again.",
         }));
         return;
@@ -62,6 +64,7 @@ export function useWalletConnection({
         setState((s) => ({
           ...s,
           connecting: false,
+          reconnecting: false,
           error: `Freighter is on the wrong network. Expected ${getActiveNetwork()}.`,
         }));
         return;
@@ -74,6 +77,7 @@ export function useWalletConnection({
         networkPassphrase,
         connected: true,
         connecting: false,
+        reconnecting: false,
         txLoading: false,
         walletType: "freighter",
         error: null,
@@ -82,6 +86,7 @@ export function useWalletConnection({
       setState((s) => ({
         ...s,
         connecting: false,
+        reconnecting: false,
         error: e instanceof Error ? e.message : "Freighter connection failed",
       }));
     }
@@ -133,6 +138,7 @@ export function useWalletConnection({
         networkPassphrase: networkConfig.networkPassphrase,
         connected: true,
         connecting: false,
+        reconnecting: false,
         txLoading: false,
         walletType: "walletconnect",
         error: null,
@@ -147,6 +153,7 @@ export function useWalletConnection({
       setState((s) => ({
         ...s,
         connecting: false,
+        reconnecting: false,
         error:
           e instanceof Error ? e.message : "WalletConnect connection failed",
       }));
@@ -158,17 +165,24 @@ export function useWalletConnection({
   useEffect(() => {
     const saved = localStorage.getItem("soroban-wallet-connected");
     if (saved === "freighter") {
+      setState((s) => ({ ...s, reconnecting: true, error: null }));
       connectFreighter();
     } else if (saved === "walletconnect") {
+      setState((s) => ({ ...s, reconnecting: true, error: null }));
       connectWalletConnect();
     }
-  }, [connectFreighter, connectWalletConnect]);
+  }, [connectFreighter, connectWalletConnect, setState]);
 
   // ── Public API ─────────────────────────────────────────────────────────────
 
   const connect = useCallback(
     async (walletType: WalletType = "freighter") => {
-      setState((s) => ({ ...s, connecting: true, error: null }));
+      setState((s) => ({
+        ...s,
+        connecting: true,
+        reconnecting: false,
+        error: null,
+      }));
       if (walletType === "walletconnect") {
         await connectWalletConnect();
       } else {

--- a/frontend/src/hooks/useWalletState.ts
+++ b/frontend/src/hooks/useWalletState.ts
@@ -6,6 +6,7 @@ export interface WalletState {
   networkPassphrase: string | null;
   connected: boolean;
   connecting: boolean;
+  reconnecting: boolean;
   txLoading: boolean;
   walletType: WalletType | null;
   error: string | null;
@@ -16,6 +17,7 @@ export const DISCONNECTED_STATE: WalletState = {
   networkPassphrase: null,
   connected: false,
   connecting: false,
+  reconnecting: false,
   txLoading: false,
   walletType: null,
   error: null,


### PR DESCRIPTION
## Summary
- Add an explicit `reconnecting` wallet state for automatic wallet restore on page load
- Keep the wallet button disabled during reconnection and show `Reconnecting…` instead of `Connect Wallet`
- Prevent manual wallet selection while a reconnect attempt is in progress
- Clear `reconnecting` on successful reconnect, connection failure, account sync, and disconnect

Closes #329.

## Verification
- `git diff --check` passed
- `npm install` is blocked on the current `frontend/package.json` because `@creit.tech/stellar-wallets-kit@^0.9.5` does not exist on npm (available versions jump from `0.9.2` to `1.0.0`)
- For local type-check smoke testing only, I temporarily installed dependencies with `@creit.tech/stellar-wallets-kit@0.9.2` and restored `frontend/package.json` before committing
- `npm run build --workspace=frontend` was attempted; the new reconnecting-state errors are resolved, but the repo still has unrelated pre-existing TypeScript failures in `App.tsx`, `CredentialsPanel.tsx`, `walletStore.ts`, SDK config types, and missing `ajv`
