### PR TITLE
fix: stable DID keys, threshold updater, expiry unit, cross-contract DID validation

### DIFF
--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes,
-    BytesN, Env, Map, String, Symbol, Vec,
+    BytesN, Env, IntoVal, Map, String, Symbol, Val, Vec,
 };
 use soroban_sdk::xdr::ToXdr;
 
@@ -25,6 +25,7 @@ const REVOKED_CNT: Symbol = symbol_short!("REVCNT");
 const ISSUER_CREDS: Symbol = symbol_short!("ISSCREDS");
 
 const MAX_ISSUERS: u32 = 100;
+const IDENTITY_REGISTRY: Symbol = symbol_short!("IDREGIST");
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 
@@ -113,7 +114,7 @@ pub struct Credential {
     pub signature: Bytes,
     /// Issuance timestamp
     pub issued_at: u64,
-    /// Optional expiry (0 = no expiry)
+    /// Optional expiry timestamp in Unix **seconds** (matches env.ledger().timestamp()). 0 = no expiry.
     pub expires_at: u64,
     /// Whether this credential has been revoked
     pub revoked: bool,
@@ -147,9 +148,10 @@ impl CredentialManager {
     /// # Errors
     /// Returns [`ContractError::AlreadyInitialized`] if the contract has already
     /// been initialized.
-    pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
+    pub fn initialize(env: Env, admin: Address, identity_registry_id: Address) -> Result<(), ContractError> {
         Self::require_uninitialized(&env)?;
         Self::set_admin(&env, &admin);
+        env.storage().instance().set(&IDENTITY_REGISTRY, &identity_registry_id);
         env.events().publish((ADMIN, symbol_short!("init")), (EVENT_VERSION, admin));
         Ok(())
     }
@@ -277,8 +279,8 @@ impl CredentialManager {
     /// * `claims_hash` - SHA-256 hash of the off-chain claims payload (32 bytes).
     ///   Stored on-chain for privacy-preserving verification.
     /// * `signature` - Issuer's signature over the credential data (64 bytes).
-    /// * `expires_at` - Unix timestamp after which the credential is invalid.
-    ///   Pass `0` for no expiry.
+    /// * `expires_at` - Unix timestamp in **seconds** after which the credential is invalid.
+    ///   Pass `0` for no expiry. Use `Date.now() / 1000` in the SDK, not `Date.now()`.
     ///
     /// # Returns
     /// The 32-byte credential ID as [`BytesN<32>`].
@@ -302,6 +304,23 @@ impl CredentialManager {
     ) -> Result<BytesN<32>, ContractError> {
         issuer.require_auth();
         Self::require_issuer(&env, &issuer)?;
+
+        // Verify subject has a registered, active DID before issuing any credential.
+        let registry_id: Address = env
+            .storage()
+            .instance()
+            .get(&IDENTITY_REGISTRY)
+            .ok_or(ContractError::NotInitialized)?;
+        let mut registry_args: Vec<Val> = Vec::new(&env);
+        registry_args.push_back(subject.clone().into_val(&env));
+        let has_did: bool = env.invoke_contract(
+            &registry_id,
+            &Symbol::new(&env, "has_active_did"),
+            registry_args,
+        );
+        if !has_did {
+            panic!("subject does not have an active DID");
+        }
 
         let now = env.ledger().timestamp();
 
@@ -870,13 +889,23 @@ mod tests {
         Bytes, Env, Map,
     };
 
+    // Minimal mock so cross-contract has_active_did calls always succeed in unit tests.
+    struct MockIdentityRegistry;
+    #[contractimpl]
+    impl MockIdentityRegistry {
+        pub fn has_active_did(_env: Env, _controller: Address) -> bool {
+            true
+        }
+    }
+
     fn setup() -> (Env, Address, CredentialManagerClient<'static>) {
         let env = Env::default();
         env.mock_all_auths();
+        let registry_id = env.register_contract(None, MockIdentityRegistry);
         let contract_id = env.register_contract(None, CredentialManager);
         let client = CredentialManagerClient::new(&env, &contract_id);
         let admin = Address::generate(&env);
-        client.initialize(&admin);
+        client.initialize(&admin, &registry_id);
         (env, admin, client)
     }
 
@@ -1076,7 +1105,8 @@ mod tests {
     #[test]
     fn test_double_initialize_returns_error() {
         let (env, admin, client) = setup();
-        let result = client.try_initialize(&admin);
+        let dummy_registry = Address::generate(&env);
+        let result = client.try_initialize(&admin, &dummy_registry);
         assert_eq!(result, Err(Ok(ContractError::AlreadyInitialized)));
     }
 
@@ -1425,12 +1455,13 @@ mod tests {
     #[test]
     fn test_list_subject_credentials_empty_subject_returns_no_cursor() {
         let (env, _admin, _client) = setup();
+        let registry_id = env.register_contract(None, MockIdentityRegistry);
         let client = CredentialManagerClient::new(
             &env,
             &env.register_contract(None, CredentialManager),
         );
         let admin = Address::generate(&env);
-        client.initialize(&admin);
+        client.initialize(&admin, &registry_id);
         let subject = Address::generate(&env);
 
         let page = client.list_subject_credentials(&subject, &None, &10, &None);

--- a/contracts/identity-registry/src/lib.rs
+++ b/contracts/identity-registry/src/lib.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env,
     Map, String, Symbol, Vec,
 };
+use soroban_sdk::xdr::ToXdr;
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 
@@ -436,8 +437,11 @@ impl IdentityRegistry {
         Ok(())
     }
 
-    fn did_key(_env: &Env, controller: &Address) -> (Symbol, Address) {
-        (IDENTITY, controller.clone())
+    // Derives a stable storage key from the raw XDR bytes of the address so the
+    // key is never affected by changes to Address::to_string() across SDK versions.
+    fn did_key(env: &Env, controller: &Address) -> (Symbol, BytesN<32>) {
+        let key_bytes = env.crypto().sha256(&controller.clone().to_xdr(env));
+        (IDENTITY, key_bytes)
     }
 
     /// Builds a `did:stellar:<address>` string from a controller address.

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -251,6 +251,35 @@ impl Reputation {
         Ok(())
     }
 
+    /// Updates the sybil thresholds stored in instance storage. Admin only.
+    ///
+    /// Emits a `ThresholdsUpdated` event so indexers can track threshold changes
+    /// without needing to diff storage snapshots.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `min_score` - New minimum score threshold.
+    /// * `min_reporters` - New minimum reporter count threshold.
+    pub fn update_thresholds(
+        env: Env,
+        min_score: i64,
+        min_reporters: u32,
+    ) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
+        env.storage().instance().set(
+            &DEF_THRESH,
+            &DefaultThreshold {
+                min_score,
+                min_reporters,
+            },
+        );
+        env.events().publish(
+            (symbol_short!("THRESH"), symbol_short!("updated")),
+            (EVENT_VERSION, min_score, min_reporters),
+        );
+        Ok(())
+    }
+
     /// Sets the default sybil threshold used by [`Self::passes_sybil_check_default`].
     ///
     /// Admin only. Stores a [`DefaultThreshold`] that callers can reference

--- a/sdk/src/credentials.ts
+++ b/sdk/src/credentials.ts
@@ -41,6 +41,28 @@ import {
 } from "./contract-args";
 
 const PROBE_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+/**
+ * Converts a JavaScript Date or millisecond timestamp to Unix seconds for use
+ * as `expiresAt` in the credential-manager contract.
+ *
+ * The contract uses `env.ledger().timestamp()` which is Unix **seconds**.
+ * JavaScript's `Date.now()` returns **milliseconds**, so passing it directly
+ * would cause credentials to expire ~1000x sooner than intended.
+ *
+ * @param dateOrMs - A `Date` object or a millisecond timestamp (e.g. `Date.now()`).
+ * @returns Unix timestamp in seconds, safe to pass as `expiresAt`.
+ *
+ * @example
+ * ```ts
+ * const expiresAt = toCredentialExpiry(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days
+ * await credentials.issueCredential(issuer, subject, type, claims, hash, expiresAt);
+ * ```
+ */
+export function toCredentialExpiry(dateOrMs: Date | number): number {
+  const ms = dateOrMs instanceof Date ? dateOrMs.getTime() : dateOrMs;
+  return Math.floor(ms / 1000);
+}
 const CREDENTIAL_NOT_FOUND_CODE = 3;
 const CREDENTIAL_REVOKED_CODE = 4;
 const CREDENTIAL_EXPIRED_CODE = 9;

--- a/sdk/src/v1.ts
+++ b/sdk/src/v1.ts
@@ -14,7 +14,7 @@
  */
 
 export { IdentityClient } from './identity';
-export { CredentialClient } from './credentials';
+export { CredentialClient, toCredentialExpiry } from './credentials';
 export { ReputationClient } from './reputation';
 export { healthCheck } from './health';
 export type { HealthCheckResult } from './health';


### PR DESCRIPTION
## Summary

- **#279** — `identity-registry`: derive storage keys from `sha256(address.to_xdr())` instead of the raw `Address` value, so keys remain stable across Soroban SDK upgrades that change `Address::to_string()` output. `to_string()` is now reserved for the human-readable `id` field in the returned DID document only.
- **#280** — `credential-manager` + SDK: add a `toCredentialExpiry(dateOrMs)` helper that divides a JS `Date`/`Date.now()` value by 1000 before passing it to the contract. The contract's `expires_at` field is documented as Unix **seconds** (matching `env.ledger().timestamp()`), not milliseconds.
- **#281** — `reputation`: add `update_thresholds(min_score, min_reporters)` — an admin-gated function that writes new threshold values to instance storage and emits a `THRESH/updated` event so indexers can track threshold changes without diffing storage.
- **#282** — `credential-manager`: `initialize` now accepts `identity_registry_id`; `issue_credential` calls `has_active_did` on the identity-registry via `env.invoke_contract` and panics if the subject has no active DID, enforcing the protocol trust model.

## Files changed

| File | Change |
|------|--------|
| `contracts/identity-registry/src/lib.rs` | Stable `did_key` via XDR bytes hash |
| `contracts/reputation/src/lib.rs` | New `update_thresholds` + event |
| `contracts/credential-manager/src/lib.rs` | `expires_at` unit comment, `initialize` registry param, cross-contract DID check |
| `sdk/src/credentials.ts` | `toCredentialExpiry` helper |
| `sdk/src/v1.ts` | Export `toCredentialExpiry` |

Closes #279
Closes #280
Closes #281
Closes #282