### PR TITLE
feat(config): validate environment variables at startup

### DIFF
--- a/server/src/config.js
+++ b/server/src/config.js
@@ -40,8 +40,110 @@ export function loadConfig(env = process.env) {
     eventPollIntervalMs: parseInteger(env.EVENT_POLL_INTERVAL_MS, 5000),
     contracts: {
       identity: env.IDENTITY_REGISTRY_ID ?? '',
-      credential: env.CREDENTIAL_MANAGER_ID ?? '',
+      credential: env.CREDENTIAL_CONTRACT_ID ?? env.CREDENTIAL_MANAGER_ID ?? '',
       reputation: env.REPUTATION_ID ?? '',
     },
   };
+}
+
+export function validateConfig(env = process.env) {
+  const missing = [];
+  const invalid = [];
+
+  const sourceAccount = env.STELLAR_SECRET_KEY ?? env.STELLAR_SOURCE_ACCOUNT;
+  if (!sourceAccount) {
+    missing.push('STELLAR_SECRET_KEY: Stellar account secret key (S…)');
+  } else {
+    if (!/^S[A-Z2-7]{55}$/.test(sourceAccount)) {
+      invalid.push('STELLAR_SECRET_KEY: Stellar account secret key must start with S and be 56 characters long');
+    }
+  }
+
+  const credentialContract = env.CREDENTIAL_CONTRACT_ID ?? env.CREDENTIAL_MANAGER_ID;
+  if (!credentialContract) {
+    missing.push('CREDENTIAL_CONTRACT_ID: deployed credential contract address');
+  } else {
+    if (!/^C[A-Z2-7]{55}$/.test(credentialContract)) {
+      invalid.push('CREDENTIAL_CONTRACT_ID: deployed credential contract address must start with C and be 56 characters long');
+    }
+  }
+
+  const numericVars = [
+    { key: 'PORT', desc: 'must be a valid integer' },
+    { key: 'EXPIRY_WARNING_DAYS', desc: 'must be a valid integer' },
+    { key: 'EXPIRY_JOB_INTERVAL_MS', desc: 'must be a valid integer' },
+    { key: 'SOROBAN_POOL_SIZE', desc: 'must be a valid integer' },
+    { key: 'RPC_CACHE_TTL_MS', desc: 'must be a valid integer' },
+    { key: 'RPC_MAX_RETRIES', desc: 'must be a valid integer' },
+    { key: 'RPC_RETRY_BASE_MS', desc: 'must be a valid integer' },
+    { key: 'RPC_RETRY_BACKOFF', desc: 'must be a valid integer' },
+    { key: 'EVENT_POLL_INTERVAL_MS', desc: 'must be a valid integer' },
+  ];
+
+  for (const item of numericVars) {
+    const val = env[item.key];
+    if (val !== undefined && val !== '') {
+      if (!/^\d+$/.test(val)) {
+        invalid.push(`${item.key}: ${item.desc}`);
+      }
+    }
+  }
+
+  const rpcUrl = env.STELLAR_RPC_URL ?? env.RPC_URL;
+  if (rpcUrl !== undefined && rpcUrl !== '') {
+    try {
+      new URL(rpcUrl);
+    } catch {
+      invalid.push('STELLAR_RPC_URL: must be a valid URL');
+    }
+  }
+
+  const webhookUrl = env.NOTIFICATION_WEBHOOK_URL;
+  if (webhookUrl !== undefined && webhookUrl !== '') {
+    try {
+      new URL(webhookUrl);
+    } catch {
+      invalid.push('NOTIFICATION_WEBHOOK_URL: must be a valid URL');
+    }
+  }
+
+  return {
+    isValid: missing.length === 0 && invalid.length === 0,
+    missing,
+    invalid,
+  };
+}
+
+export function logDefaultValues(env = process.env) {
+  const defaults = [
+    { key: 'PORT', defaultVal: '3001' },
+    { key: 'ADMIN_API_KEY', defaultVal: "''" },
+    { key: 'ADMIN_ACTOR', defaultVal: "'admin'" },
+    { key: 'DATA_DIR', defaultVal: 'data' },
+    { key: 'EXPIRY_WARNING_DAYS', defaultVal: '7' },
+    { key: 'EXPIRY_JOB_INTERVAL_MS', defaultVal: '3600000' },
+    { key: 'NOTIFICATION_WEBHOOK_URL', defaultVal: "''" },
+    { key: 'SUBJECT_NOTIFICATION_WEBHOOKS', defaultVal: '{}' },
+    { key: 'SOROBAN_POOL_SIZE', defaultVal: '4' },
+    { key: 'STELLAR_CLI', defaultVal: "'stellar'" },
+    { key: 'STELLAR_NETWORK', defaultVal: "'testnet'" },
+    { key: 'STELLAR_RPC_URL', defaultVal: "'https://soroban-testnet.stellar.org'" },
+    { key: 'RPC_CACHE_TTL_MS', defaultVal: '5000' },
+    { key: 'RPC_MAX_RETRIES', defaultVal: '3' },
+    { key: 'RPC_RETRY_BASE_MS', defaultVal: '500' },
+    { key: 'RPC_RETRY_BACKOFF', defaultVal: '2' },
+    { key: 'EVENT_POLL_INTERVAL_MS', defaultVal: '5000' },
+  ];
+
+  for (const item of defaults) {
+    let val;
+    if (item.key === 'STELLAR_RPC_URL') {
+      val = env.STELLAR_RPC_URL ?? env.RPC_URL;
+    } else {
+      val = env[item.key];
+    }
+    if (val === undefined || val === '') {
+      console.log(`[config] [INFO] Optional variable ${item.key} is using default value: ${item.defaultVal}`);
+    }
+  }
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,10 +1,29 @@
 import http from 'node:http';
-import { loadConfig } from './config.js';
+import { loadConfig, validateConfig, logDefaultValues } from './config.js';
 import { createApp } from './app.js';
 import { ensureDataDir } from './storage.js';
 import { ExpiryNotificationJob } from './expiry.js';
 import { MetricsAggregator, MetricsService } from './metrics.js';
 import { SorobanClient } from './soroban.js';
+
+const validationResult = validateConfig();
+if (!validationResult.isValid) {
+  if (validationResult.missing.length > 0) {
+    console.error('[config] Missing required environment variables:');
+    for (const err of validationResult.missing) {
+      console.error(`  - ${err}`);
+    }
+  }
+  if (validationResult.invalid.length > 0) {
+    console.error('[config] Invalid environment variables:');
+    for (const err of validationResult.invalid) {
+      console.error(`  - ${err}`);
+    }
+  }
+  process.exit(1);
+}
+
+logDefaultValues();
 
 const config = loadConfig();
 await ensureDataDir(config);

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { spawn } from 'node:child_process';
+import { validateConfig } from '../src/config.js';
+
+test('validateConfig directly: empty env returns validation errors', () => {
+  const result = validateConfig({});
+  assert.equal(result.isValid, false);
+  assert.ok(result.missing.some(e => e.includes('STELLAR_SECRET_KEY')));
+  assert.ok(result.missing.some(e => e.includes('CREDENTIAL_CONTRACT_ID')));
+});
+
+test('validateConfig directly: valid required env passes', () => {
+  const result = validateConfig({
+    STELLAR_SECRET_KEY: 'SAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    CREDENTIAL_CONTRACT_ID: 'CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  });
+  assert.equal(result.isValid, true);
+});
+
+test('validateConfig directly: invalid formats trigger invalid errors', () => {
+  const result = validateConfig({
+    STELLAR_SECRET_KEY: 'not-a-secret-key',
+    CREDENTIAL_CONTRACT_ID: 'not-a-contract-address',
+    PORT: 'abc',
+    STELLAR_RPC_URL: 'not-a-url',
+  });
+  assert.equal(result.isValid, false);
+  assert.ok(result.invalid.some(e => e.includes('STELLAR_SECRET_KEY')));
+  assert.ok(result.invalid.some(e => e.includes('CREDENTIAL_CONTRACT_ID')));
+  assert.ok(result.invalid.some(e => e.includes('PORT')));
+  assert.ok(result.invalid.some(e => e.includes('STELLAR_RPC_URL')));
+});
+
+// Helper to spawn index.js with specific environment overrides
+function runServer(envOverrides) {
+  return new Promise((resolve) => {
+    // Strip process.env credentials to ensure clean testing environment
+    const baseEnv = { ...process.env };
+    delete baseEnv.STELLAR_SECRET_KEY;
+    delete baseEnv.STELLAR_SOURCE_ACCOUNT;
+    delete baseEnv.CREDENTIAL_CONTRACT_ID;
+    delete baseEnv.CREDENTIAL_MANAGER_ID;
+
+    const child = spawn('node', ['src/index.js'], {
+      env: {
+        ...baseEnv,
+        PORT: '0',
+        DISABLE_EXPIRY_JOB: 'true',
+        DATA_DIR: 'data/test-config',
+        ...envOverrides,
+      },
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let resolved = false;
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+      if (stdout.includes('listening on :') && !resolved) {
+        resolved = true;
+        child.kill();
+        resolve({ code: null, stdout, stderr });
+      }
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('close', (code) => {
+      if (!resolved) {
+        resolve({ code, stdout, stderr });
+      }
+    });
+  });
+}
+
+test('Integration: starting with no env vars prints missing required variables and exits 1', async () => {
+  const result = await runServer({
+    STELLAR_SECRET_KEY: '',
+    STELLAR_SOURCE_ACCOUNT: '',
+    CREDENTIAL_CONTRACT_ID: '',
+    CREDENTIAL_MANAGER_ID: '',
+  });
+
+  assert.equal(result.code, 1);
+  assert.ok(result.stderr.includes('[config] Missing required environment variables:'));
+  assert.ok(result.stderr.includes('STELLAR_SECRET_KEY: Stellar account secret key (S…)'));
+  assert.ok(result.stderr.includes('CREDENTIAL_CONTRACT_ID: deployed credential contract address'));
+});
+
+test('Integration: starting with all required vars binds the port normally', async () => {
+  const result = await runServer({
+    STELLAR_SECRET_KEY: 'SAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    CREDENTIAL_CONTRACT_ID: 'CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  });
+
+  assert.ok(result.stdout.includes('listening on :') || result.code === 0 || result.code === null);
+});
+
+test('Integration: invalid URL for RPC_URL triggers a validation error and exits 1', async () => {
+  const result = await runServer({
+    STELLAR_SECRET_KEY: 'SAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    CREDENTIAL_CONTRACT_ID: 'CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    STELLAR_RPC_URL: 'invalid-url',
+  });
+
+  assert.equal(result.code, 1);
+  assert.ok(result.stderr.includes('STELLAR_RPC_URL: must be a valid URL'));
+});


### PR DESCRIPTION
This PR implements environment variable validation at server startup, printing missing and invalid variables, and exiting with code 1. It also logs default values for optional variables on startup.

closes #346