### PR TITLE
fix: two-step admin transfer, remove_subject_reporter, stderr capture (#277 #278 #325 #326)

### DIFF
--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -16,6 +16,7 @@ const EVENT_VERSION: u32 = 1;
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
 const ADMIN: Symbol = symbol_short!("ADMIN");
+const PENDING_ADMIN: Symbol = symbol_short!("PADMIN");
 const ISSUER: Symbol = symbol_short!("ISSUER");
 const CRED: Symbol = symbol_short!("CRED");
 const SUBJECT: Symbol = symbol_short!("sub");
@@ -41,6 +42,8 @@ pub enum ContractError {
     Unauthorized = 7,
     MaxIssuersReached = 8,
     CredentialExpired = 9,
+    NoPendingAdmin = 10,
+    NotPendingAdmin = 11,
 }
 
 /// ~1 year in ledgers (5-second ledger close time). Used as the max TTL cap.
@@ -183,6 +186,68 @@ impl CredentialManager {
         env.events().publish(
             (ADMIN, symbol_short!("transfer")),
             (EVENT_VERSION, current_admin, new_admin),
+        );
+        Ok(())
+    }
+
+    /// Proposes a new admin via two-step transfer (admin only).
+    ///
+    /// The proposed admin must subsequently call [`Self::accept_admin`] to complete
+    /// the transfer. This prevents accidental transfers to uncontrolled addresses.
+    ///
+    /// # Errors
+    /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
+    /// Returns [`ContractError::Unauthorized`] if `admin` is not the current admin.
+    pub fn propose_admin(
+        env: Env,
+        admin: Address,
+        proposed: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .ok_or(ContractError::NotInitialized)?;
+        if stored != admin {
+            return Err(ContractError::Unauthorized);
+        }
+        env.storage().instance().set(&PENDING_ADMIN, &proposed);
+        env.events().publish(
+            (ADMIN, symbol_short!("proposed")),
+            (EVENT_VERSION, admin, proposed),
+        );
+        Ok(())
+    }
+
+    /// Accepts a pending admin proposal (proposed admin only).
+    ///
+    /// Must be called by the address previously nominated via [`Self::propose_admin`].
+    /// Completes the two-step admin transfer and clears the pending slot.
+    ///
+    /// # Errors
+    /// Returns [`ContractError::NoPendingAdmin`] if no admin proposal is pending.
+    /// Returns [`ContractError::NotPendingAdmin`] if the caller is not the proposed admin.
+    pub fn accept_admin(env: Env, proposed: Address) -> Result<(), ContractError> {
+        proposed.require_auth();
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&PENDING_ADMIN)
+            .ok_or(ContractError::NoPendingAdmin)?;
+        if pending != proposed {
+            return Err(ContractError::NotPendingAdmin);
+        }
+        env.storage().instance().remove(&PENDING_ADMIN);
+        let old_admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .ok_or(ContractError::NotInitialized)?;
+        env.storage().instance().set(&ADMIN, &proposed);
+        env.events().publish(
+            (ADMIN, symbol_short!("accepted")),
+            (EVENT_VERSION, old_admin, proposed),
         );
         Ok(())
     }

--- a/contracts/identity-registry/src/lib.rs
+++ b/contracts/identity-registry/src/lib.rs
@@ -20,6 +20,8 @@ pub enum ContractError {
     DidAlreadyExists = 7,
     NotInitialized = 8,
     MetadataTooLarge = 9,
+    NoPendingAdmin = 10,
+    NotPendingAdmin = 11,
 }
 
 /// Version returned by `ping` for deployment health checks.
@@ -33,6 +35,7 @@ const EVENT_VERSION: u32 = 1;
 
 const IDENTITY: Symbol = symbol_short!("IDENTITY");
 const ADMIN: Symbol = symbol_short!("ADMIN");
+const PENDING_ADMIN: Symbol = symbol_short!("PADMIN");
 const DID_COUNT: Symbol = symbol_short!("DIDCNT");
 const TOTAL_DIDS: Symbol = symbol_short!("TOTDIDS");
 
@@ -147,6 +150,68 @@ impl IdentityRegistry {
         env.events().publish(
             (ADMIN, symbol_short!("transfer")),
             (EVENT_VERSION, current_admin, new_admin),
+        );
+        Ok(())
+    }
+
+    /// Proposes a new admin via two-step transfer (admin only).
+    ///
+    /// The proposed admin must subsequently call [`Self::accept_admin`] to complete
+    /// the transfer. This prevents accidental transfers to uncontrolled addresses.
+    ///
+    /// # Errors
+    /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
+    /// Returns [`ContractError::Unauthorized`] if `admin` is not the current admin.
+    pub fn propose_admin(
+        env: Env,
+        admin: Address,
+        proposed: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .ok_or(ContractError::NotInitialized)?;
+        if stored != admin {
+            return Err(ContractError::Unauthorized);
+        }
+        env.storage().instance().set(&PENDING_ADMIN, &proposed);
+        env.events().publish(
+            (ADMIN, symbol_short!("proposed")),
+            (EVENT_VERSION, admin, proposed),
+        );
+        Ok(())
+    }
+
+    /// Accepts a pending admin proposal (proposed admin only).
+    ///
+    /// Must be called by the address previously nominated via [`Self::propose_admin`].
+    /// Completes the two-step admin transfer and clears the pending slot.
+    ///
+    /// # Errors
+    /// Returns [`ContractError::NoPendingAdmin`] if no admin proposal is pending.
+    /// Returns [`ContractError::NotPendingAdmin`] if the caller is not the proposed admin.
+    pub fn accept_admin(env: Env, proposed: Address) -> Result<(), ContractError> {
+        proposed.require_auth();
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&PENDING_ADMIN)
+            .ok_or(ContractError::NoPendingAdmin)?;
+        if pending != proposed {
+            return Err(ContractError::NotPendingAdmin);
+        }
+        env.storage().instance().remove(&PENDING_ADMIN);
+        let old_admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .ok_or(ContractError::NotInitialized)?;
+        env.storage().instance().set(&ADMIN, &proposed);
+        env.events().publish(
+            (ADMIN, symbol_short!("accepted")),
+            (EVENT_VERSION, old_admin, proposed),
         );
         Ok(())
     }

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -17,6 +17,7 @@ pub const CONTRACT_VERSION: u32 = 1;
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
 const ADMIN: Symbol = symbol_short!("ADMIN");
+const PENDING_ADMIN: Symbol = symbol_short!("PADMIN");
 const REPORTER: Symbol = symbol_short!("REPORTER");
 const DEF_THRESH: Symbol = symbol_short!("DEFTHRESH");
 const SUBJECT_CNT: Symbol = symbol_short!("SUBCNT");
@@ -36,6 +37,8 @@ pub enum ContractError {
     ReasonTooLong = 4,
     NotInitialized = 5,
     Unauthorized = 6,
+    NoPendingAdmin = 7,
+    NotPendingAdmin = 8,
 }
 
 /// Schema version stamped on every emitted event. Increment on breaking schema changes
@@ -153,6 +156,68 @@ impl Reputation {
         Ok(())
     }
 
+    /// Proposes a new admin via two-step transfer (admin only).
+    ///
+    /// The proposed admin must subsequently call [`Self::accept_admin`] to complete
+    /// the transfer. This prevents accidental transfers to uncontrolled addresses.
+    ///
+    /// # Errors
+    /// Returns [`ContractError::NotInitialized`] if the contract has not been initialized.
+    /// Returns [`ContractError::Unauthorized`] if `admin` is not the current admin.
+    pub fn propose_admin(
+        env: Env,
+        admin: Address,
+        proposed: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .ok_or(ContractError::NotInitialized)?;
+        if stored != admin {
+            return Err(ContractError::Unauthorized);
+        }
+        env.storage().instance().set(&PENDING_ADMIN, &proposed);
+        env.events().publish(
+            (ADMIN, symbol_short!("proposed")),
+            (EVENT_VERSION, admin, proposed),
+        );
+        Ok(())
+    }
+
+    /// Accepts a pending admin proposal (proposed admin only).
+    ///
+    /// Must be called by the address previously nominated via [`Self::propose_admin`].
+    /// Completes the two-step admin transfer and clears the pending slot.
+    ///
+    /// # Errors
+    /// Returns [`ContractError::NoPendingAdmin`] if no admin proposal is pending.
+    /// Returns [`ContractError::NotPendingAdmin`] if the caller is not the proposed admin.
+    pub fn accept_admin(env: Env, proposed: Address) -> Result<(), ContractError> {
+        proposed.require_auth();
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&PENDING_ADMIN)
+            .ok_or(ContractError::NoPendingAdmin)?;
+        if pending != proposed {
+            return Err(ContractError::NotPendingAdmin);
+        }
+        env.storage().instance().remove(&PENDING_ADMIN);
+        let old_admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .ok_or(ContractError::NotInitialized)?;
+        env.storage().instance().set(&ADMIN, &proposed);
+        env.events().publish(
+            (ADMIN, symbol_short!("accepted")),
+            (EVENT_VERSION, old_admin, proposed),
+        );
+        Ok(())
+    }
+
     /// Transfers admin rights to a new address. Only the current admin can call this.
     ///
     /// # Arguments
@@ -248,6 +313,44 @@ impl Reputation {
             (REPORTER, symbol_short!("removed")),
             (EVENT_VERSION, reporter, env.ledger().timestamp()),
         );
+        Ok(())
+    }
+
+    /// Removes a specific reporter's history for a subject and decrements reporter_count (admin only).
+    ///
+    /// Used to invalidate contributions from a compromised reporter address for a
+    /// particular subject. Clears the per-(subject, reporter) history entry and
+    /// decrements `reporter_count` on the subject's [`ReputationRecord`] with
+    /// saturation at zero.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `subject` - The subject address whose record to update.
+    /// * `reporter` - The reporter whose history entry to remove.
+    pub fn remove_subject_reporter(
+        env: Env,
+        subject: Address,
+        reporter: Address,
+    ) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
+        let history_key = Self::history_key(&subject, &reporter);
+        if env.storage().persistent().has(&history_key) {
+            env.storage().persistent().remove(&history_key);
+            let rec_key = Self::record_key(&subject);
+            if let Some(mut record) = env
+                .storage()
+                .persistent()
+                .get::<(Symbol, Address), ReputationRecord>(&rec_key)
+            {
+                record.reporter_count = record.reporter_count.saturating_sub(1);
+                env.storage().persistent().set(&rec_key, &record);
+                env.storage().persistent().extend_ttl(&rec_key, TTL_MAX, TTL_MAX);
+            }
+            env.events().publish(
+                (REPORTER, symbol_short!("removed")),
+                (EVENT_VERSION, subject, reporter),
+            );
+        }
         Ok(())
     }
 

--- a/server/src/soroban.js
+++ b/server/src/soroban.js
@@ -168,6 +168,23 @@ export class SorobanClient {
   }
 }
 
+function runCommand(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    child.stdout.on('data', (chunk) => stdoutChunks.push(chunk));
+    child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const stdout = stdoutChunks.join('');
+      const stderr = stderrChunks.join('').slice(0, 4096);
+      if (code === 0) resolve(stdout);
+      else reject(new Error(`command failed: ${stderr || stdout || `exit code ${code}`}`));
+    });
+  });
+}
+
 function parseAddressList(raw) {
   const matches = raw.match(/G[A-Z0-9]{55}/g);
   return matches ? [...new Set(matches)] : [];


### PR DESCRIPTION
## Summary

- **#277 (backend: no admin transfer mechanism)** — Added `propose_admin(admin, proposed)` and `accept_admin(proposed)` to all three contracts (`credential-manager`, `identity-registry`, `reputation`). The current admin proposes a successor; the successor must explicitly call `accept_admin` to complete the transfer, preventing accidental lock-out to uncontrolled addresses. Pending admin is stored in instance storage under `PADMIN`. Two new error variants added: `NoPendingAdmin` and `NotPendingAdmin`.
- **#278 (reputation reporter_count not decrementable)** — Added `remove_subject_reporter(subject, reporter)` (admin-only) to the reputation contract. It removes the per-`(subject, reporter)` history entry from persistent storage and decrements `reporter_count` on the subject's `ReputationRecord` with saturation at zero, allowing invalidation of a compromised reporter's contributions.
- **#325 (useCredentialExpiryCheck setState after unmount)** — The hook already returns `() => clearInterval(intervalRef.current)` from its `useEffect`. No code change required; closing via this PR.
- **#326 (SorobanClient.invoke discards stderr)** — Added the missing `runCommand` function to `server/src/soroban.js`. It captures stdout and stderr via `child.stdout/stderr` data events and, on non-zero exit, rejects with an `Error` whose message contains up to 4 KB of stderr so operators can diagnose failures without re-running commands manually.

## Test plan

- [ ] `cargo test -p credential-manager` — existing tests pass; verify `propose_admin`/`accept_admin` compile
- [ ] `cargo test -p identity-registry` — existing tests pass
- [ ] `cargo test -p reputation` — existing tests pass; `remove_subject_reporter` compiles
- [ ] `server/src/soroban.js` — call a broken `stellar` CLI path; confirm the thrown error message contains the CLI stderr

Closes #277, closes #278, closes #325, closes #326