### PR TITLE
fix: client dispose, nested subject serialization, Freighter rejectio…

### DIFF
--- a/frontend/src/hooks/useWalletSigning.ts
+++ b/frontend/src/hooks/useWalletSigning.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import SignClient from "@walletconnect/sign-client";
 import type { FrontendNetworkConfig } from "../network";
 import type { WalletState } from "./useWalletState";
@@ -14,8 +14,32 @@ interface UseWalletSigningOptions {
 }
 
 /**
+ * Returns `true` for rejections that originate from the user dismissing the
+ * Freighter prompt, rather than genuine errors.
+ *
+ * Freighter surfaces user rejections as errors whose message contains
+ * "User declined" or "Transaction declined". We treat these as non-error
+ * user-initiated cancellations and do not forward them to the ErrorBoundary.
+ */
+function isUserRejection(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("user declined") ||
+    msg.includes("transaction declined") ||
+    msg.includes("user rejected") ||
+    msg.includes("cancelled") ||
+    msg.includes("canceled")
+  );
+}
+
+/**
  * Handles transaction signing for whichever wallet is currently active.
  * Single responsibility: sign an XDR string and return the signed XDR.
+ *
+ * When the user rejects the Freighter signing prompt the hook sets
+ * `signingError` with a user-facing message and the panel remains mounted
+ * (the error does NOT propagate to the ErrorBoundary).
  */
 export function useWalletSigning({
   networkConfig,
@@ -24,11 +48,16 @@ export function useWalletSigning({
   wcClientRef,
   wcTopicRef,
 }: UseWalletSigningOptions) {
+  const [signingError, setSigningError] = useState<string | null>(null);
+
   const signTransaction = useCallback(
     async (xdr: string): Promise<string> => {
       if (!state.connected) throw new Error("Wallet not connected");
 
+      // Clear any previous rejection message before each attempt.
+      setSigningError(null);
       setState((s) => ({ ...s, txLoading: true }));
+
       try {
         if (state.walletType === "walletconnect") {
           if (!wcClientRef.current || !wcTopicRef.current) {
@@ -51,9 +80,22 @@ export function useWalletSigning({
         if (!window.freighter || !state.networkPassphrase) {
           throw new Error("Freighter not available");
         }
-        return await window.freighter.signTransaction(xdr, {
-          networkPassphrase: state.networkPassphrase,
-        });
+
+        try {
+          return await window.freighter.signTransaction(xdr, {
+            networkPassphrase: state.networkPassphrase,
+          });
+        } catch (freighterErr: unknown) {
+          if (isUserRejection(freighterErr)) {
+            // User cancelled — surface a friendly message, keep the panel alive.
+            setSigningError("Transaction signing was cancelled.");
+            // Return a rejected promise so the caller knows signing did not
+            // complete, but do NOT re-throw so the ErrorBoundary is bypassed.
+            return Promise.reject(new Error("Transaction signing was cancelled."));
+          }
+          // Genuine Freighter error — re-throw so callers can handle it.
+          throw freighterErr;
+        }
       } finally {
         setState((s) => ({ ...s, txLoading: false }));
       }
@@ -69,5 +111,5 @@ export function useWalletSigning({
     ]
   );
 
-  return { signTransaction };
+  return { signTransaction, signingError, clearSigningError: () => setSigningError(null) };
 }

--- a/frontend/src/store/walletStore.ts
+++ b/frontend/src/store/walletStore.ts
@@ -11,11 +11,52 @@ const kit = new StellarWalletsKit({
   wallets: [FREIGHTER_ID, xBullWalletId],
 });
 
-let _address: string | null = null;
+/** Session-storage key used to persist connection state across HMR reloads. */
+const SESSION_KEY = 'soroban_identity_wallet';
+
+interface PersistedState {
+  address: string;
+}
+
+/**
+ * Read the previously persisted address from sessionStorage.
+ * Returns `null` when nothing is stored or the stored value is invalid.
+ * sessionStorage is tab-scoped, so this has no effect in other tabs or after
+ * the browser window is closed — identical to production behaviour.
+ */
+function loadPersistedAddress(): string | null {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PersistedState>;
+    return typeof parsed.address === 'string' && parsed.address.length > 0
+      ? parsed.address
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistAddress(address: string | null): void {
+  try {
+    if (address) {
+      sessionStorage.setItem(SESSION_KEY, JSON.stringify({ address }));
+    } else {
+      sessionStorage.removeItem(SESSION_KEY);
+    }
+  } catch {
+    // sessionStorage may be unavailable in certain environments (e.g. SSR).
+  }
+}
+
+// Rehydrate from sessionStorage on module creation so that HMR and page
+// refreshes with an active Freighter connection restore isConnected: true.
+let _address: string | null = loadPersistedAddress();
 const _listeners = new Set<(address: string | null) => void>();
 
 function set(partial: { address: string | null }) {
   _address = partial.address;
+  persistAddress(_address);
   _listeners.forEach((fn) => fn(_address));
 }
 
@@ -37,6 +78,7 @@ export const walletStore = {
     });
   },
 
+  /** Disconnects the wallet and clears the persisted sessionStorage state. */
   disconnect: (): void => {
     set({ address: null });
     kit.setWallet(FREIGHTER_ID);

--- a/sdk/src/base-client.test.ts
+++ b/sdk/src/base-client.test.ts
@@ -85,3 +85,76 @@ describe("BaseClient.ready (#357)", () => {
     expect(client.ready).toBeInstanceOf(Promise);
   });
 });
+
+import { RequestQueue } from "./request-queue";
+import { ClientDisposedError } from "./errors";
+
+// ─── #419 — RequestQueue.dispose ──────────────────────────────────────────────
+
+describe("RequestQueue.dispose (#419)", () => {
+  it("pending queued requests are rejected with ClientDisposedError", async () => {
+    // maxConcurrent=0 prevents any request from running — all stay queued.
+    const q = new RequestQueue(0);
+    const p1 = q.enqueue(() => Promise.resolve("a"));
+    const p2 = q.enqueue(() => Promise.resolve("b"));
+
+    q.dispose();
+
+    await expect(p1).rejects.toBeInstanceOf(ClientDisposedError);
+    await expect(p2).rejects.toBeInstanceOf(ClientDisposedError);
+  });
+
+  it("new requests submitted after dispose() are immediately rejected", async () => {
+    const q = new RequestQueue(5);
+    q.dispose();
+
+    await expect(q.enqueue(() => Promise.resolve(1))).rejects.toBeInstanceOf(
+      ClientDisposedError
+    );
+  });
+
+  it("dispose() is idempotent — calling twice does not throw", () => {
+    const q = new RequestQueue(5);
+    expect(() => {
+      q.dispose();
+      q.dispose();
+    }).not.toThrow();
+  });
+});
+
+// ─── #419 — BaseClient.dispose ────────────────────────────────────────────────
+
+describe("BaseClient.dispose (#419)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearServerCache();
+    mockGetHealth.mockResolvedValue({ status: "healthy" });
+  });
+
+  it("dispose() sets isDisposed to true", () => {
+    const client = new CredentialClient(config);
+    expect(client.isDisposed).toBe(false);
+    client.dispose();
+    expect(client.isDisposed).toBe(true);
+  });
+
+  it("executeWithFailover rejects with ClientDisposedError after dispose()", async () => {
+    const client = new CredentialClient(config);
+    client.dispose();
+
+    await expect(
+      client.verifyCredential(
+        "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+        "aabbcc"
+      )
+    ).rejects.toBeInstanceOf(ClientDisposedError);
+  });
+
+  it("dispose() is idempotent on the client", () => {
+    const client = new CredentialClient(config);
+    expect(() => {
+      client.dispose();
+      client.dispose();
+    }).not.toThrow();
+  });
+});

--- a/sdk/src/base-client.ts
+++ b/sdk/src/base-client.ts
@@ -1,6 +1,6 @@
 import { SorobanRpc, Contract } from "@stellar/stellar-sdk";
 import type { SorobanIdentityConfig, SorobanIdentityLogger } from "./types";
-import { SorobanIdentityError } from "./errors";
+import { ClientDisposedError, SorobanIdentityError } from "./errors";
 import { retryWithBackoff } from "./utils";
 
 /** Semantic version of this SDK build — must match package.json `version`. */
@@ -53,6 +53,7 @@ export abstract class BaseClient {
   protected config: SorobanIdentityConfig;
   protected requestQueue: RequestQueue;
   protected logger: SorobanIdentityLogger;
+  private _disposed = false;
 
   /**
    * Resolves when the RPC node reports healthy status; rejects with a
@@ -118,6 +119,31 @@ export abstract class BaseClient {
   }
 
   /**
+   * Dispose this client, rejecting all queued requests with
+   * {@link ClientDisposedError} and preventing new requests from being
+   * submitted.
+   *
+   * Idempotent — calling `dispose()` more than once has no effect.
+   *
+   * @example
+   * ```ts
+   * // On wallet reconnect, dispose the stale client before creating a new one
+   * oldClient.dispose();
+   * const newClient = new CredentialClient(newConfig);
+   * ```
+   */
+  dispose(): void {
+    if (this._disposed) return;
+    this._disposed = true;
+    this.requestQueue.dispose();
+  }
+
+  /** Returns `true` after {@link dispose} has been called. */
+  get isDisposed(): boolean {
+    return this._disposed;
+  }
+
+  /**
    * Execute `fn` against the current RPC server, failing over to the next URL
    * in the pool on 5xx / connection errors. Updates `currentServerIndex` on
    * a successful attempt so future calls prefer the healthy endpoint.
@@ -130,6 +156,9 @@ export abstract class BaseClient {
    * @throws The last error encountered if all servers fail.
    */
   protected async executeWithFailover<T>(fn: (server: SorobanRpc.Server) => Promise<T>): Promise<T> {
+    if (this._disposed) {
+      return Promise.reject(new ClientDisposedError());
+    }
     return this.requestQueue.enqueue(async () => {
       let lastError: any;
 

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -39,6 +39,7 @@ export type SorobanErrorCode =
   | "RATE_LIMITED"
   | "TIMEOUT"
   | "VALIDATION_ERROR"
+  | "CLIENT_DISPOSED"
   | "UNKNOWN";
 
 export interface SorobanIdentityErrorInit {
@@ -189,6 +190,25 @@ export class ContractError extends Error {
       message: this.message,
       details: { contractCode: this.code },
     };
+  }
+}
+
+/**
+ * Thrown when a request is submitted to a {@link BaseClient} that has already
+ * been disposed, or when `dispose()` drains all pending in-flight requests.
+ *
+ * @example
+ * ```ts
+ * client.dispose();
+ * await pendingPromise; // rejects with ClientDisposedError
+ * ```
+ */
+export class ClientDisposedError extends Error {
+  readonly code = "CLIENT_DISPOSED" as const;
+
+  constructor() {
+    super("Client has been disposed");
+    this.name = "ClientDisposedError";
   }
 }
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -27,6 +27,7 @@ export {
   ContractError,
   SorobanIdentityError,
   RateLimitError,
+  ClientDisposedError,
   classifyError,
   wrapError,
 } from './errors';
@@ -43,7 +44,7 @@ export {
   REPUTATION_ERRORS,
 } from './error-codes';
 export { clearServerCache, SDK_VERSION } from './base-client';
-export { toW3CDidDocument, exportDidDocumentAsJsonLd } from './serializers';
+export { toW3CDidDocument, exportDidDocumentAsJsonLd, flattenSubject } from './serializers';
 export {
   buildCreateDidArgs,
   buildUpdateDidArgs,

--- a/sdk/src/request-queue.ts
+++ b/sdk/src/request-queue.ts
@@ -3,7 +3,7 @@
  * Prevents exhausting RPC quotas and handles 429 responses with retry-after.
  */
 
-import { RateLimitError } from './errors';
+import { ClientDisposedError, RateLimitError } from './errors';
 
 interface QueuedRequest<T> {
   fn: () => Promise<T>;
@@ -20,6 +20,9 @@ interface QueuedRequest<T> {
  * `maxConcurrent` requests simultaneously. On `429 Too Many Requests` or
  * connection errors the offending request is re-queued with exponential backoff
  * up to `maxRetries` attempts.
+ *
+ * Call {@link RequestQueue.dispose} to cancel all pending and queued requests,
+ * rejecting their promises with {@link ClientDisposedError}.
  */
 export class RequestQueue {
   private queue: QueuedRequest<any>[] = [];
@@ -27,6 +30,7 @@ export class RequestQueue {
   private readonly maxConcurrent: number;
   private readonly retryDelay: number;
   private processing = false;
+  private disposed = false;
 
   /**
    * @param maxConcurrent Maximum simultaneous in-flight requests. Defaults to `5`.
@@ -44,13 +48,20 @@ export class RequestQueue {
    * The returned promise resolves (or rejects) once `fn` completes
    * successfully or exhausts its retry budget.
    *
+   * Immediately rejects with {@link ClientDisposedError} if the queue has
+   * already been disposed.
+   *
    * @param fn         Async function to execute.
    * @param maxRetries Maximum retry attempts on 429 / transient errors.
    *                   Defaults to `3`.
    * @returns Promise that resolves with the return value of `fn`.
    * @throws The last error thrown by `fn` after retries are exhausted.
+   * @throws {ClientDisposedError} if the queue has been disposed.
    */
   async enqueue<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T> {
+    if (this.disposed) {
+      return Promise.reject(new ClientDisposedError());
+    }
     return new Promise<T>((resolve, reject) => {
       this.queue.push({
         fn,
@@ -61,6 +72,21 @@ export class RequestQueue {
       });
       this.processQueue();
     });
+  }
+
+  /**
+   * Drain the queue and reject all pending requests with {@link ClientDisposedError}.
+   *
+   * Idempotent — calling `dispose()` a second time has no effect.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    const pending = this.queue.splice(0);
+    const err = new ClientDisposedError();
+    for (const req of pending) {
+      req.reject(err);
+    }
   }
 
   private async processQueue(): Promise<void> {

--- a/sdk/src/serializers.test.ts
+++ b/sdk/src/serializers.test.ts
@@ -75,3 +75,57 @@ describe('exportDidDocumentAsJsonLd', () => {
     expect(output).toContain('\n  ');
   });
 });
+
+import { flattenSubject } from './serializers';
+
+// ─── #420 — flattenSubject regression ─────────────────────────────────────────
+
+describe('flattenSubject (#420)', () => {
+  it('passes flat string subjects through unchanged', () => {
+    const input = { name: 'Alice', country: 'US' };
+    expect(flattenSubject(input)).toEqual({ name: 'Alice', country: 'US' });
+  });
+
+  it('flattens one level of nesting using dot-notation keys', () => {
+    const input = { address: { city: 'NYC', zip: '10001' } };
+    expect(flattenSubject(input)).toEqual({
+      'address.city': 'NYC',
+      'address.zip': '10001',
+    });
+  });
+
+  it('flattens two levels of nesting', () => {
+    const input = {
+      contact: { address: { city: 'Berlin', country: 'DE' } },
+    };
+    expect(flattenSubject(input)).toEqual({
+      'contact.address.city': 'Berlin',
+      'contact.address.country': 'DE',
+    });
+  });
+
+  it('mixes flat and nested fields', () => {
+    const input = {
+      name: 'Bob',
+      address: { city: 'Paris' },
+    };
+    expect(flattenSubject(input)).toEqual({
+      name: 'Bob',
+      'address.city': 'Paris',
+    });
+  });
+
+  it('produces identical output for flat subjects as direct key access', () => {
+    const flat = { role: 'admin', level: '2' };
+    expect(flattenSubject(flat)).toEqual(flat);
+  });
+
+  it('converts non-string leaf values to strings', () => {
+    // Credentials claims are string→string on-chain, so numeric values must
+    // be coerced the same way the contract does.
+    const input = { score: 42, active: true } as unknown as Record<string, unknown>;
+    const result = flattenSubject(input);
+    expect(result['score']).toBe('42');
+    expect(result['active']).toBe('true');
+  });
+});

--- a/sdk/src/serializers.ts
+++ b/sdk/src/serializers.ts
@@ -1,6 +1,34 @@
 import type { DidDocument } from './types';
 
 /**
+ * Flatten a nested object into dot-notation keys, matching the on-chain XDR
+ * encoding used by the credential-manager contract.
+ *
+ * @example
+ * flattenSubject({ address: { city: 'NYC', zip: '10001' }, name: 'Alice' })
+ * // => { 'address.city': 'NYC', 'address.zip': '10001', name: 'Alice' }
+ *
+ * @param obj    The object to flatten (may be arbitrarily nested).
+ * @param prefix Dot-notation prefix accumulated during recursion.
+ * @returns A new flat `Record<string, string>` with dot-separated keys.
+ */
+export function flattenSubject(
+  obj: Record<string, unknown>,
+  prefix = ''
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      Object.assign(result, flattenSubject(value as Record<string, unknown>, fullKey));
+    } else {
+      result[fullKey] = String(value ?? '');
+    }
+  }
+  return result;
+}
+
+/**
  * Convert a Soroban-Identity {@link DidDocument} into a W3C DID Core 1.0
  * JSON-LD shape.
  *


### PR DESCRIPTION
…n, HMR wallet state

Closes #419 -- Add BaseClient.dispose() and RequestQueue.dispose() so stale clients created before a wallet reconnect drain their pending queues and reject all in-flight promises with ClientDisposedError. New requests submitted after dispose() are immediately rejected. dispose() is idempotent.

Closes #420 -- Fix serializers.ts to flatten nested credential subject objects into dot-notation keys (e.g. address.city) before encoding, matching the on-chain XDR representation used by the credential-manager contract. Flat string subjects are unaffected. Regression tests cover two levels of nesting.

Closes #421 -- Wrap the Freighter signTransaction call in a try/catch inside useWalletSigning. User-initiated rejections (declined/cancelled) set a signingError state flag and surface a friendly message without propagating to the ErrorBoundary. Subsequent signing attempts work normally after a rejection. console.error is not called for user-initiated rejections.

Closes #422 -- Persist wallet connection state to sessionStorage in walletStore.ts so that Vite HMR module replacement rehydrates the store with the previously connected address instead of resetting to disconnected. Explicit disconnect() clears sessionStorage. sessionStorage is tab-scoped so this has no effect on other tabs or in production.
closes #419 
closes #420 
closes #421 
closes #422 