### PR TITLE
feat: implement issues #409, #410, #411, #426

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,20 +1,34 @@
-# Active network (testnet | mainnet)
+# ── Required ──────────────────────────────────────────────────────────────────
+# These must be set or the app will throw an error before any component mounts.
+
+# Soroban RPC server URL (e.g. https://soroban-testnet.stellar.org)
+VITE_SERVER_URL=
+
+# Stellar network passphrase
+VITE_NETWORK_PASSPHRASE=
+
+# Primary Soroban contract ID
+VITE_CONTRACT_ID=
+
+# ── Active network ─────────────────────────────────────────────────────────────
+# testnet | mainnet
 VITE_NETWORK=testnet
 
-# Testnet
+# ── Testnet ────────────────────────────────────────────────────────────────────
 VITE_TESTNET_RPC_URL=https://soroban-testnet.stellar.org
 VITE_TESTNET_IDENTITY_REGISTRY_ID=
 VITE_TESTNET_CREDENTIAL_MANAGER_ID=
 VITE_TESTNET_REPUTATION_ID=
 
-# Mainnet
+# ── Mainnet ────────────────────────────────────────────────────────────────────
 VITE_MAINNET_RPC_URL=https://soroban-mainnet.stellar.org
 VITE_MAINNET_IDENTITY_REGISTRY_ID=
 VITE_MAINNET_CREDENTIAL_MANAGER_ID=
 VITE_MAINNET_REPUTATION_ID=
 
-# WalletConnect
+# ── WalletConnect ──────────────────────────────────────────────────────────────
 VITE_WALLETCONNECT_PROJECT_ID=
 
-# Optional server event stream URL
+# ── Optional ───────────────────────────────────────────────────────────────────
+# Server-sent events stream URL
 VITE_EVENTS_URL=http://localhost:3001/events

--- a/frontend/src/components/CredentialsPanel.tsx
+++ b/frontend/src/components/CredentialsPanel.tsx
@@ -419,7 +419,7 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
         </div>
 
         {fetching ? (
-          <SkeletonCard rows={3} />
+          <SkeletonCard variant="credential" />
         ) : fetchedCredentials !== null && fetchedCredentials.length === 0 ? (
           <div style={{ textAlign: "center", padding: "2rem 1rem", color: "var(--text-muted)" }}>
             <div style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>🪪</div>
@@ -547,7 +547,7 @@ export default function CredentialsPanel({ verifyId }: { verifyId?: string | nul
         <button onClick={() => void handleVerify()} disabled={verifying || !credId}>
           {verifying ? "Verifying…" : "Verify"}
         </button>
-        {verifying && <SkeletonCard rows={2} />}
+        {verifying && <SkeletonCard variant="credential" />}
         {!verifying && verifyState !== "idle" && (
           <div style={{ marginTop: "1rem" }}>
             {verifyState === "valid" && (

--- a/frontend/src/components/IdentityPanel.tsx
+++ b/frontend/src/components/IdentityPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useReducer } from 'react';
+import { useState, useReducer, useEffect, useRef } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
 import { StrKey } from '@stellar/stellar-sdk';
 import type { WalletState } from '../hooks/useWallet';
@@ -56,6 +56,14 @@ export default function IdentityPanel() {
   const [resolveAddress, setResolveAddress] = useState('');
   const [showHistory, setShowHistory] = useState(false);
   const { history, addAddress, clearHistory } = useAddressHistory();
+
+  const prevConnected = useRef(wallet.connected);
+  useEffect(() => {
+    if (prevConnected.current && !wallet.connected) {
+      clearHistory();
+    }
+    prevConnected.current = wallet.connected;
+  }, [wallet.connected, clearHistory]);
 
   const [createResult, setCreateResult] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -363,7 +371,7 @@ export default function IdentityPanel() {
         <button onClick={handleResolve} disabled={resolving || !resolveAddress}>
           {resolving ? 'Resolving…' : 'Resolve'}
         </button>
-        {resolving && <SkeletonCard rows={4} />}
+        {resolving && <SkeletonCard variant="identity" />}
         {!resolving && resolveResult && (
           <>
             <div style={{ 

--- a/frontend/src/components/SkeletonCard.tsx
+++ b/frontend/src/components/SkeletonCard.tsx
@@ -1,8 +1,59 @@
+export type SkeletonVariant = 'credential' | 'identity' | 'reputation';
+
 interface Props {
   rows?: number;
+  variant?: SkeletonVariant;
 }
 
-export default function SkeletonCard({ rows = 3 }: Props) {
+function CredentialSkeleton() {
+  return (
+    <div className="card skeleton-card" aria-busy="true" aria-label="Loading…">
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
+        <div className="skeleton" style={{ width: '2rem', height: '2rem', borderRadius: '0.25rem', flexShrink: 0 }} />
+        <div className="skeleton skeleton-title" style={{ flex: 1 }} />
+        <div className="skeleton" style={{ width: '4rem', height: '1.2rem', borderRadius: '999px' }} />
+        <div className="skeleton" style={{ width: '3.5rem', height: '1.2rem', borderRadius: '999px' }} />
+      </div>
+      <div className="skeleton skeleton-row" style={{ width: '100%' }} />
+      <div className="skeleton skeleton-row" style={{ width: '75%' }} />
+    </div>
+  );
+}
+
+function IdentitySkeleton() {
+  return (
+    <div className="card skeleton-card" aria-busy="true" aria-label="Loading…">
+      <div className="skeleton skeleton-title" style={{ width: '60%', marginBottom: '0.75rem' }} />
+      <div className="skeleton skeleton-row" style={{ width: '100%' }} />
+      <div className="skeleton skeleton-row" style={{ width: '100%' }} />
+      <div className="skeleton skeleton-row" style={{ width: '85%' }} />
+      <div className="skeleton skeleton-row" style={{ width: '90%' }} />
+      <div className="skeleton skeleton-row" style={{ width: '60%' }} />
+    </div>
+  );
+}
+
+function ReputationSkeleton() {
+  return (
+    <div className="card skeleton-card" aria-busy="true" aria-label="Loading…">
+      <div className="skeleton skeleton-title" style={{ width: '40%', marginBottom: '0.75rem' }} />
+      <div style={{ display: 'flex', gap: '1rem', marginBottom: '0.5rem' }}>
+        <div className="skeleton" style={{ width: '3rem', height: '3rem', borderRadius: '50%' }} />
+        <div style={{ flex: 1 }}>
+          <div className="skeleton skeleton-row" style={{ width: '100%' }} />
+          <div className="skeleton skeleton-row" style={{ width: '60%' }} />
+        </div>
+      </div>
+      <div className="skeleton skeleton-row" style={{ width: '100%', height: '4rem' }} />
+    </div>
+  );
+}
+
+export default function SkeletonCard({ rows = 3, variant }: Props) {
+  if (variant === 'credential') return <CredentialSkeleton />;
+  if (variant === 'identity') return <IdentitySkeleton />;
+  if (variant === 'reputation') return <ReputationSkeleton />;
+
   return (
     <div className="card skeleton-card" aria-busy="true" aria-label="Loading…">
       <div className="skeleton skeleton-title" />

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,5 +1,22 @@
 import { getNetworkConfig } from './network';
 
+const REQUIRED_VARS: Record<string, string | undefined> = {
+  VITE_SERVER_URL: import.meta.env.VITE_SERVER_URL,
+  VITE_NETWORK_PASSPHRASE: import.meta.env.VITE_NETWORK_PASSPHRASE,
+  VITE_CONTRACT_ID: import.meta.env.VITE_CONTRACT_ID,
+};
+
+const missing = Object.entries(REQUIRED_VARS)
+  .filter(([, v]) => !v)
+  .map(([k]) => k);
+
+if (missing.length > 0) {
+  throw new Error(
+    `Missing required environment variables: ${missing.join(', ')}. ` +
+      'Check frontend/.env.example for the full list of required variables.'
+  );
+}
+
 // Returns config for the active network, resolved from VITE_NETWORK / VITE_*_RPC_URL
 // / VITE_*_IDENTITY_REGISTRY_ID env vars defined in .env.example.
 export function getAppConfig() {

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 import { useWallet } from "../hooks/useWallet";
 import type { WalletState } from "../hooks/useWalletState";
 import type { FrontendNetworkConfig } from "../network";
@@ -15,8 +15,30 @@ const WalletContext = createContext<WalletContextValue | null>(null);
 export function WalletProvider({ children }: { children: ReactNode }) {
   const networkConfig: FrontendNetworkConfig = getNetworkConfig();
   const wallet = useWallet(networkConfig);
+
+  const value = useMemo(
+    () => wallet,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      wallet.publicKey,
+      wallet.connected,
+      wallet.networkPassphrase,
+      wallet.connecting,
+      wallet.txLoading,
+      wallet.walletType,
+      wallet.error,
+      wallet.retryCount,
+      wallet.isConnecting,
+      wallet.connectionError,
+      wallet.connect,
+      wallet.disconnect,
+      wallet.signTransaction,
+      wallet.retry,
+    ]
+  );
+
   return (
-    <WalletContext.Provider value={wallet}>{children}</WalletContext.Provider>
+    <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
   );
 }
 

--- a/frontend/src/hooks/useAddressHistory.ts
+++ b/frontend/src/hooks/useAddressHistory.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 
-const STORAGE_KEY = "soroban_identity_address_history";
-const MAX_ENTRIES = 5;
+const STORAGE_KEY = "soroban-identity:addressHistory";
+const MAX_ENTRIES = 10;
 
 export function useAddressHistory() {
   const [history, setHistory] = useState<string[]>([]);


### PR DESCRIPTION
## Summary

Implements four frontend issues in one branch. Each change is scoped to the files described in the respective issue.

---

### Closes #409 — `useAddressHistory`: persist address history to localStorage

**Files:** `frontend/src/hooks/useAddressHistory.ts`, `frontend/src/components/IdentityPanel.tsx`

- Changed `STORAGE_KEY` from `soroban_identity_address_history` to the canonical `soroban-identity:addressHistory` key.
- Raised `MAX_ENTRIES` from 5 → **10**, evicting the oldest entry once the cap is reached.
- The hook already reads from `localStorage` on mount and writes on every update, so history now survives hard page refreshes.
- Added a `useEffect` + `useRef` guard in `IdentityPanel` that detects when `wallet.connected` transitions `true → false` (explicit user disconnect) and calls `clearHistory()`, satisfying the "cleared on disconnect" acceptance criterion without wiping history on initial page load.

---

### Closes #410 — `config.ts`: validate required env vars at module load

**Files:** `frontend/src/config.ts`, `frontend/.env.example`

- `config.ts` now reads `VITE_SERVER_URL`, `VITE_NETWORK_PASSPHRASE`, and `VITE_CONTRACT_ID` at module load time and throws a descriptive `Error` listing every missing variable by name — before any component mounts. Vite's dev overlay surfaces this immediately instead of producing cryptic network errors later.
- Updated `frontend/.env.example` with a clearly labelled **Required** section documenting all three new variables alongside the existing network-specific vars.

---

### Closes #411 — `SkeletonCard`: variant prop matching real card dimensions

**Files:** `frontend/src/components/SkeletonCard.tsx`, `frontend/src/components/CredentialsPanel.tsx`, `frontend/src/components/IdentityPanel.tsx`

Added a `variant` prop (`'credential' | 'identity' | 'reputation'`) to `SkeletonCard`. Each variant renders placeholder bars whose dimensions mirror the corresponding real card layout, eliminating layout shift:

- **`credential`** — icon placeholder + title bar + type/status badge pills + two content rows, matching `CredentialsPanel` list items.
- **`identity`** — title + five content rows matching the DID document `<pre>` block in `IdentityPanel`.
- **`reputation`** — title + avatar circle + two rows + tall chart bar, matching the `ReputationChart` card.
- Falls back to the original `rows`-based generic skeleton when no variant is passed (backwards-compatible).

Updated every existing usage:
- `CredentialsPanel` credential list → `variant="credential"`
- `CredentialsPanel` verify row → `variant="credential"`
- `IdentityPanel` resolve → `variant="identity"`

---

### Closes #426 — `WalletContext`: memoize provider value to stop unnecessary re-renders

**Files:** `frontend/src/context/WalletContext.tsx`

- Imported `useMemo` and wrapped the value passed to `WalletContext.Provider` in a `useMemo` keyed on every field that can actually change: `publicKey`, `connected`, `networkPassphrase`, `connecting`, `txLoading`, `walletType`, `error`, `retryCount`, `isConnecting`, `connectionError`, and the stable callback references (`connect`, `disconnect`, `signTransaction`, `retry`).
- The context value reference is now only replaced when wallet state genuinely changes, preventing `CredentialsPanel`, `IdentityPanel`, and `ReputationChart` from re-rendering on unrelated parent state updates.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)