### PR TITLE
feat: resolve issues #412, #413, #417, #418 — i18n locale switching, OpenAPI 4xx schemas, 409 Conflict on duplicate credential, fee estimation

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,376 @@
+openapi: '3.0.3'
+info:
+  title: Soroban Identity API
+  version: '1.0.0'
+  description: REST API for issuing, verifying, and revoking Soroban-backed verifiable credentials and DID documents.
+
+servers:
+  - url: http://localhost:3001
+    description: Local development
+
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code.
+          example: CREDENTIAL_NOT_FOUND
+        message:
+          type: string
+          description: Human-readable error description.
+          example: Credential "abc123" not found.
+        details:
+          type: array
+          description: Optional list of field-level error details.
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+              value:
+                type: string
+
+    Credential:
+      type: object
+      required:
+        - id
+        - subject
+        - issuer
+        - credentialType
+        - claims
+        - claimsHash
+        - signature
+        - issuedAt
+        - expiresAt
+        - revoked
+      properties:
+        id:
+          type: string
+          description: Hex-encoded 32-byte credential ID.
+        subject:
+          type: string
+          description: Stellar address of the credential subject.
+        issuer:
+          type: string
+          description: Stellar address of the issuing party.
+        credentialType:
+          type: string
+          enum: [Kyc, Reputation, Achievement, Custom]
+        claims:
+          type: object
+          additionalProperties:
+            type: string
+        claimsHash:
+          type: string
+          description: SHA-256 hash of the off-chain claims payload (hex).
+        signature:
+          type: string
+        issuedAt:
+          type: integer
+          description: Unix timestamp of issuance.
+        expiresAt:
+          type: integer
+          description: Unix timestamp of expiry; 0 means no expiry.
+        revoked:
+          type: boolean
+
+    DidDocument:
+      type: object
+      required:
+        - id
+        - controller
+        - metadata
+        - createdAt
+        - updatedAt
+        - active
+      properties:
+        id:
+          type: string
+          description: DID in did:stellar:<address> format.
+        controller:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+        createdAt:
+          type: integer
+        updatedAt:
+          type: integer
+        active:
+          type: boolean
+
+paths:
+  /credentials:
+    post:
+      summary: Issue a new verifiable credential
+      operationId: issueCredential
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Credential'
+      responses:
+        '201':
+          description: Credential issued successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Credential'
+        '400':
+          description: Request body is missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Caller is not authenticated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a registered issuer.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: A credential with this ID already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                code: CREDENTIAL_ALREADY_EXISTS
+                message: Credential with ID "abc123" already exists.
+                details:
+                  - field: id
+                    value: abc123
+        '422':
+          description: Credential data failed validation (e.g. invalid claims hash).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /credentials/{id}:
+    get:
+      summary: Retrieve a credential by ID
+      operationId: getCredential
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Hex-encoded credential ID.
+      responses:
+        '200':
+          description: Credential found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Credential'
+        '400':
+          description: The provided ID is not valid hex.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Credential not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      summary: Revoke a credential
+      operationId: revokeCredential
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Credential revoked.
+        '401':
+          description: Caller is not authenticated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not the issuer of this credential.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Credential not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /identities:
+    post:
+      summary: Create a new DID document
+      operationId: createIdentity
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - controller
+              properties:
+                controller:
+                  type: string
+                metadata:
+                  type: object
+                  additionalProperties:
+                    type: string
+      responses:
+        '201':
+          description: DID created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DidDocument'
+        '400':
+          description: Missing or invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Caller is not authenticated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: A DID already exists for this controller.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Controller address is not a valid Stellar address.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /identities/{address}:
+    get:
+      summary: Resolve a DID document
+      operationId: resolveIdentity
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Stellar address (G…) of the DID controller.
+      responses:
+        '200':
+          description: DID document found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DidDocument'
+        '400':
+          description: The provided address is not a valid Stellar address.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: No DID found for this address.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      summary: Deactivate a DID
+      operationId: deactivateIdentity
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: DID deactivated.
+        '401':
+          description: Caller is not authenticated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not the DID controller.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: No DID found for this address.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /reputations/{address}:
+    get:
+      summary: Get reputation record for a Stellar address
+      operationId: getReputation
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Stellar address (G…).
+      responses:
+        '200':
+          description: Reputation record found.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subject:
+                    type: string
+                  score:
+                    type: integer
+                  reporters:
+                    type: integer
+                  lastUpdated:
+                    type: integer
+        '400':
+          description: The provided address is not a valid Stellar address.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: No reputation record found for this address.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,13 @@ import { useCredentialExpiryCheck } from "./hooks/useCredentialExpiryCheck";
 import { checkConnection, TESTNET_CONFIG, IdentityClient, CredentialClient, ReputationClient } from "../../sdk/src/index";
 import { getAppConfig } from "./config";
 import { getActiveNetwork, getNetworkConfig, isMainnet } from "./network";
+import { setLocale } from "./i18n";
 import type { Credential } from "../../sdk/src/types";
+
+const SUPPORTED_LOCALES: { code: string; label: string }[] = [
+  { code: "en", label: "EN" },
+  { code: "es", label: "ES" },
+];
 
 type Tab = "identity" | "credentials";
 
@@ -113,10 +119,8 @@ export default function App() {
     fetchCredentials,
   );
 
-  const toggleLang = () => {
-    const next = i18n.language === "en" ? "es" : "en";
-    i18n.changeLanguage(next);
-    localStorage.setItem("lang", next);
+  const handleLocaleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setLocale(e.target.value);
   };
 
   return (
@@ -163,13 +167,16 @@ export default function App() {
               {isConnected ? t("app.networkOnline") : t("app.networkOffline")}
             </div>
           )}
-          <button
-            className="theme-toggle"
-            onClick={toggleLang}
+          <select
+            value={i18n.language}
+            onChange={handleLocaleChange}
             aria-label="Switch language"
+            style={{ padding: "0.3rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}
           >
-            {i18n.language === "en" ? "ES" : "EN"}
-          </button>
+            {SUPPORTED_LOCALES.map(({ code, label }) => (
+              <option key={code} value={code}>{label}</option>
+            ))}
+          </select>
           <button
             className="theme-toggle"
             onClick={toggleDark}

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -3,11 +3,24 @@ import { initReactI18next } from "react-i18next";
 import en from "./locales/en.json";
 import es from "./locales/es.json";
 
+const SUPPORTED_LOCALES: Record<string, object> = {
+  en: { translation: en },
+  es: { translation: es },
+};
+
+const STORAGE_KEY = "lang";
+
 i18n.use(initReactI18next).init({
-  resources: { en: { translation: en }, es: { translation: es } },
-  lng: localStorage.getItem("lang") ?? "en",
+  resources: SUPPORTED_LOCALES,
+  lng: localStorage.getItem(STORAGE_KEY) ?? "en",
   fallbackLng: "en",
   interpolation: { escapeValue: false },
 });
+
+export function setLocale(locale: string): void {
+  const resolved = SUPPORTED_LOCALES[locale] ? locale : "en";
+  localStorage.setItem(STORAGE_KEY, resolved);
+  i18n.changeLanguage(resolved);
+}
 
 export default i18n;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -26,7 +26,9 @@ export type {
   IdentityStorageStats,
   CredentialStorageStats,
   ReputationStorageStats,
+  FeeEstimate,
 } from './types';
+export { SimulationError } from './types';
 export type { ReputationRecord, ScoreHistoryEntry } from './reputation';
 export type { EventFilter, ContractEvent } from './events';
 import type { SorobanIdentityConfig } from './types';

--- a/sdk/src/transaction-builder.ts
+++ b/sdk/src/transaction-builder.ts
@@ -3,8 +3,10 @@ import {
   TransactionBuilder,
   xdr,
   BASE_FEE,
+  SorobanRpc,
 } from '@stellar/stellar-sdk';
-import type { SorobanIdentityConfig } from './types';
+import type { SorobanIdentityConfig, FeeEstimate } from './types';
+import { SimulationError } from './types';
 import type { Account } from '@stellar/stellar-sdk';
 
 /**
@@ -78,25 +80,49 @@ export class SorobanTransactionBuilder {
   }
 
   /**
-   * Get the list of operations (for testing).
-   * @returns Array of operations
+   * Simulate the transaction and return fee breakdown before signing.
+   * Does not prompt for a signature.
    */
+  async estimateFee(operation: xdr.Operation): Promise<FeeEstimate> {
+    const server = new SorobanRpc.Server(this.config.rpcUrl);
+    const builder = new TransactionBuilder(this.account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    });
+    builder.addOperation(operation);
+    builder.setTimeout(30);
+    const tx = builder.build();
+
+    const result = await server.simulateTransaction(tx);
+
+    if (SorobanRpc.Api.isSimulationError(result)) {
+      throw new SimulationError(
+        result.error ?? 'Transaction simulation failed',
+        result,
+      );
+    }
+
+    const baseFee = parseInt(BASE_FEE, 10);
+    const resourceFee = parseInt(
+      (result as SorobanRpc.Api.SimulateTransactionSuccessResponse).minResourceFee ?? '0',
+      10,
+    );
+
+    return {
+      baseFee,
+      resourceFee,
+      totalFee: baseFee + resourceFee,
+    };
+  }
+
   getOperations(): xdr.Operation[] {
     return this.operations;
   }
 
-  /**
-   * Get the account (for testing).
-   * @returns The account
-   */
   getAccount(): Account {
     return this.account;
   }
 
-  /**
-   * Get the config (for testing).
-   * @returns The config
-   */
   getConfig(): SorobanIdentityConfig {
     return this.config;
   }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -68,3 +68,19 @@ export interface ReputationStorageStats {
   totalSubjects: number;
   totalScoreEntries: number;
 }
+
+export interface FeeEstimate {
+  /** Base network fee in stroops. */
+  baseFee: number;
+  /** Soroban resource fee in stroops. */
+  resourceFee: number;
+  /** Total fee (baseFee + resourceFee) in stroops. */
+  totalFee: number;
+}
+
+export class SimulationError extends Error {
+  constructor(message: string, public readonly raw?: unknown) {
+    super(message);
+    this.name = 'SimulationError';
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const express = require('express');
+const { CredentialStore } = require('./storage');
+const credentialsRouter = require('./routes/credentials');
+
+const app = express();
+app.use(express.json());
+
+const credentialStore = new CredentialStore();
+app.use('/credentials', credentialsRouter(credentialStore));
+
+const PORT = process.env.PORT ?? 3001;
+app.listen(PORT, () => {
+  console.log(`Soroban Identity server running on port ${PORT}`);
+});
+
+module.exports = app;

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1,0 +1,324 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Soroban Identity API",
+    "version": "1.0.0",
+    "description": "REST API for issuing, verifying, and revoking Soroban-backed verifiable credentials and DID documents."
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3001",
+      "description": "Local development"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Machine-readable error code.",
+            "example": "CREDENTIAL_NOT_FOUND"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error description.",
+            "example": "Credential \"abc123\" not found."
+          },
+          "details": {
+            "type": "array",
+            "description": "Optional list of field-level error details.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": { "type": "string" },
+                "value": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "Credential": {
+        "type": "object",
+        "required": ["id", "subject", "issuer", "credentialType", "claims", "claimsHash", "signature", "issuedAt", "expiresAt", "revoked"],
+        "properties": {
+          "id": { "type": "string", "description": "Hex-encoded 32-byte credential ID." },
+          "subject": { "type": "string", "description": "Stellar address of the credential subject." },
+          "issuer": { "type": "string", "description": "Stellar address of the issuing party." },
+          "credentialType": { "type": "string", "enum": ["Kyc", "Reputation", "Achievement", "Custom"] },
+          "claims": { "type": "object", "additionalProperties": { "type": "string" } },
+          "claimsHash": { "type": "string", "description": "SHA-256 hash of the off-chain claims payload (hex)." },
+          "signature": { "type": "string" },
+          "issuedAt": { "type": "integer", "description": "Unix timestamp of issuance." },
+          "expiresAt": { "type": "integer", "description": "Unix timestamp of expiry; 0 means no expiry." },
+          "revoked": { "type": "boolean" }
+        }
+      },
+      "DidDocument": {
+        "type": "object",
+        "required": ["id", "controller", "metadata", "createdAt", "updatedAt", "active"],
+        "properties": {
+          "id": { "type": "string", "description": "DID in did:stellar:<address> format." },
+          "controller": { "type": "string" },
+          "metadata": { "type": "object", "additionalProperties": { "type": "string" } },
+          "createdAt": { "type": "integer" },
+          "updatedAt": { "type": "integer" },
+          "active": { "type": "boolean" }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/credentials": {
+      "post": {
+        "summary": "Issue a new verifiable credential",
+        "operationId": "issueCredential",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Credential" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Credential issued successfully.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Credential" }
+              }
+            }
+          },
+          "400": {
+            "description": "Request body is missing required fields.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "401": {
+            "description": "Caller is not authenticated.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "403": {
+            "description": "Caller is not a registered issuer.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "409": {
+            "description": "A credential with this ID already exists.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+                "example": {
+                  "code": "CREDENTIAL_ALREADY_EXISTS",
+                  "message": "Credential with ID \"abc123\" already exists.",
+                  "details": [{ "field": "id", "value": "abc123" }]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Credential data failed validation (e.g. invalid claims hash).",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          }
+        }
+      }
+    },
+    "/credentials/{id}": {
+      "get": {
+        "summary": "Retrieve a credential by ID",
+        "operationId": "getCredential",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Hex-encoded credential ID."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Credential found.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Credential" } } }
+          },
+          "400": {
+            "description": "The provided ID is not valid hex.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Revoke a credential",
+        "operationId": "revokeCredential",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "Credential revoked." },
+          "401": {
+            "description": "Caller is not authenticated.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "403": {
+            "description": "Caller is not the issuer of this credential.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          }
+        }
+      }
+    },
+    "/identities": {
+      "post": {
+        "summary": "Create a new DID document",
+        "operationId": "createIdentity",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["controller"],
+                "properties": {
+                  "controller": { "type": "string" },
+                  "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "DID created successfully.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DidDocument" } } }
+          },
+          "400": {
+            "description": "Missing or invalid request body.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "401": {
+            "description": "Caller is not authenticated.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "409": {
+            "description": "A DID already exists for this controller.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "422": {
+            "description": "Controller address is not a valid Stellar address.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          }
+        }
+      }
+    },
+    "/identities/{address}": {
+      "get": {
+        "summary": "Resolve a DID document",
+        "operationId": "resolveIdentity",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Stellar address (G…) of the DID controller."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "DID document found.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DidDocument" } } }
+          },
+          "400": {
+            "description": "The provided address is not a valid Stellar address.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "404": {
+            "description": "No DID found for this address.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Deactivate a DID",
+        "operationId": "deactivateIdentity",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "DID deactivated." },
+          "401": {
+            "description": "Caller is not authenticated.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "403": {
+            "description": "Caller is not the DID controller.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "404": {
+            "description": "No DID found for this address.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          }
+        }
+      }
+    },
+    "/reputations/{address}": {
+      "get": {
+        "summary": "Get reputation record for a Stellar address",
+        "operationId": "getReputation",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Stellar address (G…)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reputation record found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "subject": { "type": "string" },
+                    "score": { "type": "integer" },
+                    "reporters": { "type": "integer" },
+                    "lastUpdated": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided address is not a valid Stellar address.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          },
+          "404": {
+            "description": "No reputation record found for this address.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/routes/credentials.js
+++ b/server/routes/credentials.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { Router } = require('express');
+const { DuplicateKeyError } = require('../storage');
+
+module.exports = function credentialsRouter(store) {
+  const router = Router();
+
+  router.post('/', (req, res) => {
+    const credential = req.body;
+
+    if (!credential || !credential.id) {
+      return res.status(400).json({
+        code: 'INVALID_REQUEST',
+        message: 'Request body must include a credential with an id field.',
+      });
+    }
+
+    try {
+      store.add(credential);
+      return res.status(201).json(store.get(credential.id));
+    } catch (err) {
+      if (err instanceof DuplicateKeyError) {
+        return res.status(409).json({
+          code: 'CREDENTIAL_ALREADY_EXISTS',
+          message: err.message,
+          details: [{ field: 'id', value: err.id }],
+        });
+      }
+      return res.status(500).json({
+        code: 'INTERNAL_ERROR',
+        message: 'An unexpected error occurred.',
+      });
+    }
+  });
+
+  router.get('/:id', (req, res) => {
+    const credential = store.get(req.params.id);
+    if (!credential) {
+      return res.status(404).json({
+        code: 'CREDENTIAL_NOT_FOUND',
+        message: `Credential "${req.params.id}" not found.`,
+      });
+    }
+    return res.json(credential);
+  });
+
+  router.delete('/:id', (req, res) => {
+    if (!store.has(req.params.id)) {
+      return res.status(404).json({
+        code: 'CREDENTIAL_NOT_FOUND',
+        message: `Credential "${req.params.id}" not found.`,
+      });
+    }
+    store.delete(req.params.id);
+    return res.status(204).end();
+  });
+
+  return router;
+};

--- a/server/storage.js
+++ b/server/storage.js
@@ -1,0 +1,36 @@
+'use strict';
+
+class DuplicateKeyError extends Error {
+  constructor(id) {
+    super(`Credential with ID "${id}" already exists`);
+    this.name = 'DuplicateKeyError';
+    this.id = id;
+  }
+}
+
+class CredentialStore {
+  constructor() {
+    this._store = new Map();
+  }
+
+  add(credential) {
+    if (this._store.has(credential.id)) {
+      throw new DuplicateKeyError(credential.id);
+    }
+    this._store.set(credential.id, { ...credential });
+  }
+
+  get(id) {
+    return this._store.get(id) ?? null;
+  }
+
+  delete(id) {
+    return this._store.delete(id);
+  }
+
+  has(id) {
+    return this._store.has(id);
+  }
+}
+
+module.exports = { CredentialStore, DuplicateKeyError };


### PR DESCRIPTION
## Summary

This PR resolves four open issues across the frontend, server, and SDK layers.

---

### Closes #412 — i18n must support runtime locale switching without a full page reload

- Exported `setLocale(locale: string)` from `frontend/src/i18n.ts`. Resolves the locale against the supported bundle map, falls back to `"en"` if no bundle exists, persists to `localStorage`, and calls `i18n.changeLanguage()` — react-i18next propagates the change to all translated strings without unmounting the root.
- Replaced the hard-coded `toggleLang` EN↔ES toggle in `App.tsx` with a `<select>` language picker that calls `setLocale`, making it trivial to add new locales later.

---

### Closes #413 — openapi.yaml is missing response schemas for all 4xx error responses

- Created `docs/openapi.yaml` with a shared `ErrorResponse` component schema (`code`, `message`, optional `details[]`).
- Every endpoint (`/credentials`, `/credentials/{id}`, `/identities`, `/identities/{address}`, `/reputations/{address}`) references `$ref: '#/components/schemas/ErrorResponse'` for all applicable 4xx codes (400, 401, 403, 404, 409, 422) — no inline duplicates.
- Created `server/openapi.json` as a JSON mirror kept in sync with the YAML.

---

### Closes #417 — server must return 409 Conflict instead of 500 when a credential already exists

- `server/storage.js`: `CredentialStore.add()` throws a typed `DuplicateKeyError` (carrying the conflicting `id`) instead of propagating a raw error.
- `server/routes/credentials.js`: `POST /credentials` catches `DuplicateKeyError` and returns `409 Conflict` with `{ code: "CREDENTIAL_ALREADY_EXISTS", message, details }`. No duplicate can produce a 500.
- `POST /credentials` in both OpenAPI files documents the 409 response.

---

### Closes #418 — SDK transaction-builder must expose fee estimation before signing

- Added `FeeEstimate` interface (`baseFee`, `resourceFee`, `totalFee` in stroops) and `SimulationError` class to `sdk/src/types.ts`.
- `SorobanTransactionBuilder.estimateFee(operation)` builds a throw-away transaction, calls `server.simulateTransaction()`, throws a typed `SimulationError` on failure, and returns the parsed `FeeEstimate` — never prompting Freighter.
- Both `FeeEstimate` and `SimulationError` are exported from `sdk/src/index.ts`.

---

## Files changed

| File | Change |
|---|---|
| `frontend/src/i18n.ts` | Add `setLocale`, `SUPPORTED_LOCALES` |
| `frontend/src/App.tsx` | Use `setLocale`, replace toggle with `<select>` picker |
| `sdk/src/types.ts` | Add `FeeEstimate`, `SimulationError` |
| `sdk/src/transaction-builder.ts` | Add `estimateFee` method |
| `sdk/src/index.ts` | Export `FeeEstimate`, `SimulationError` |
| `docs/openapi.yaml` | New — full spec with `ErrorResponse` and 4xx on all endpoints |
| `server/openapi.json` | New — JSON mirror of openapi.yaml |
| `server/storage.js` | New — `CredentialStore` + `DuplicateKeyError` |
| `server/routes/credentials.js` | New — POST/GET/DELETE with 409 conflict handling |
| `server/index.js` | New — Express entry point |

🤖 Generated with [Claude Code](https://claude.com/claude-code)