### PR TITLE
Feat/401 402 reactivate did cap issuer creds

### DIFF
--- a/contracts/credential-manager/src/lib.rs
+++ b/contracts/credential-manager/src/lib.rs
@@ -38,6 +38,7 @@ const REVOKED_CNT: Symbol = symbol_short!("REVCNT");
 const ISSUER_CREDS: Symbol = symbol_short!("ISSCREDS");
 
 const MAX_ISSUERS: u32 = 100;
+const MAX_ISSUER_CREDS: u32 = 10_000;
 const IDENTITY_REGISTRY: Symbol = symbol_short!("IDREGIST");
 
 // ── Errors ────────────────────────────────────────────────────────────────────
@@ -487,7 +488,12 @@ impl CredentialManager {
             .extend_ttl(&subject_key, TTL_MAX, TTL_MAX);
 
         // Index credential under issuer for reverse lookup
+        // Apply ring-buffer semantics: cap at MAX_ISSUER_CREDS
         let mut issuer_creds = Self::fetch_issuer_creds(&env, &issuer);
+        if issuer_creds.len() >= MAX_ISSUER_CREDS {
+            // Drop the oldest (head) entry
+            issuer_creds = issuer_creds.slice(1..issuer_creds.len());
+        }
         issuer_creds.push_back(id.clone());
         let issuer_creds_key = Self::issuer_creds_key(&issuer);
         env.storage().persistent().set(&issuer_creds_key, &issuer_creds);
@@ -1699,5 +1705,48 @@ mod tests {
             client.try_issue_credential(&rando, &rando, &CredentialType::Kyc, &claims, &sig, &0u64),
             Err(Ok(CredentialError::NotAnIssuer))
         );
+    }
+
+    /// Ring-buffer eviction: when issuer index reaches MAX_ISSUER_CREDS,
+    /// issuing the (MAX_ISSUER_CREDS + 1)th credential drops the oldest entry.
+    #[test]
+    fn test_issuer_credentials_ring_buffer_eviction() {
+        let (env, _admin, client) = setup();
+        let issuer = Address::generate(&env);
+        client.add_issuer(&issuer);
+
+        // Issue MAX_ISSUER_CREDS credentials from different subjects
+        let mut first_id = None;
+        for i in 0..MAX_ISSUER_CREDS {
+            let subject = Address::generate(&env);
+            let id = issue_kyc(&env, &client, &issuer, &subject);
+            if i == 0 {
+                first_id = Some(id);
+            }
+        }
+
+        // Index should be at MAX_ISSUER_CREDS
+        let creds_before = client.get_issuer_credentials(&issuer);
+        assert_eq!(creds_before.len(), MAX_ISSUER_CREDS as u32);
+
+        // Issue one more credential — should not panic and index stays at MAX_ISSUER_CREDS
+        let new_subject = Address::generate(&env);
+        let _new_id = issue_kyc(&env, &client, &issuer, &new_subject);
+
+        let creds_after = client.get_issuer_credentials(&issuer);
+        assert_eq!(creds_after.len(), MAX_ISSUER_CREDS as u32);
+
+        // The first credential ID should have been evicted (removed from head)
+        if let Some(first) = first_id {
+            // Verify first_id is NOT in the list after eviction
+            let mut found = false;
+            for cred_id in creds_after.iter() {
+                if cred_id == first {
+                    found = true;
+                    break;
+                }
+            }
+            assert!(!found, "First credential ID should have been evicted from the index");
+        }
     }
 }

--- a/contracts/identity-registry/src/lib.rs
+++ b/contracts/identity-registry/src/lib.rs
@@ -452,6 +452,57 @@ impl IdentityRegistry {
         Ok(())
     }
 
+    /// Reactivates a deactivated DID. Only the admin can call this.
+    ///
+    /// Sets `active=true` and updates `updated_at` on the existing document.
+    /// If the DID is already active, this is a no-op and returns `Ok(())`.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `admin` - The admin address (must sign the transaction).
+    /// * `controller` - The address whose DID to reactivate.
+    ///
+    /// # Errors
+    /// Returns [`ContractError::Unauthorized`] if `admin` is not the current admin.
+    /// Returns [`ContractError::DidNotFound`] if no DID exists for the controller.
+    pub fn reactivate_did(env: Env, admin: Address, controller: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .ok_or(ContractError::NotInitialized)?;
+        if stored_admin != admin {
+            return Err(ContractError::Unauthorized);
+        }
+
+        let storage = env.storage().persistent();
+        let key = Self::did_key(&env, &controller);
+        let mut doc: DidDocument = storage.get(&key).ok_or(ContractError::DidNotFound)?;
+
+        // No-op if already active
+        if doc.active {
+            return Ok(());
+        }
+
+        doc.active = true;
+        doc.updated_at = env.ledger().timestamp();
+
+        storage.set(&key, &doc);
+        storage.extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+
+        // Increment active DID count
+        let count: u32 = env.storage().instance().get(&DID_COUNT).unwrap_or(0);
+        env.storage().instance().set(&DID_COUNT, &(count + 1));
+
+        env.events().publish(
+            (IDENTITY, symbol_short!("reactivated")),
+            (EVENT_VERSION, controller, doc.updated_at),
+        );
+        Ok(())
+    }
+
     /// Resolve a DID document by controller address.
     pub fn resolve_did(env: Env, controller: Address) -> Result<DidDocument, IdentityError> {
         let key = Self::did_key(&env, &controller);
@@ -979,5 +1030,84 @@ mod tests {
         let addr_part = &did_str[DID_STELLAR_PREFIX.len()..];
         assert_eq!(addr_part, expected_addr);
         assert!(IdentityRegistry::validate_did_format(&env, &did));
+    }
+
+    /// reactivate_did called by non-admin returns Unauthorized.
+    #[test]
+    fn test_reactivate_did_unauthorized_non_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, IdentityRegistry);
+        let client = IdentityRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let non_admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.create_did(&user, &Map::new(&env));
+        client.deactivate_did(&user);
+
+        let result = client.try_reactivate_did(&non_admin, &user);
+        assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+    }
+
+    /// reactivate_did on an already-active DID is a no-op and returns Ok.
+    #[test]
+    fn test_reactivate_did_already_active_is_noop() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, IdentityRegistry);
+        let client = IdentityRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.create_did(&user, &Map::new(&env));
+
+        // DID is already active; reactivate should be a no-op
+        let result = client.try_reactivate_did(&admin, &user);
+        assert_eq!(result, Ok(Ok(())));
+
+        // Verify DID is still active
+        assert!(client.has_active_did(&user));
+    }
+
+    /// reactivate_did restores an active DID and increments count.
+    #[test]
+    fn test_reactivate_did_restores_active_did() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, IdentityRegistry);
+        let client = IdentityRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.create_did(&user, &Map::new(&env));
+
+        assert_eq!(client.get_did_count(), 1);
+        assert!(client.has_active_did(&user));
+
+        // Deactivate
+        client.deactivate_did(&user);
+        assert_eq!(client.get_did_count(), 0);
+        assert!(!client.has_active_did(&user));
+
+        // Reactivate
+        let result = client.try_reactivate_did(&admin, &user);
+        assert_eq!(result, Ok(Ok(())));
+
+        assert_eq!(client.get_did_count(), 1);
+        assert!(client.has_active_did(&user));
+
+        // Verify the document is now active
+        let doc = client.resolve_did(&user);
+        assert!(doc.active);
     }
 }


### PR DESCRIPTION
# feat: Add reactivate_did and cap issuer credentials index to prevent DoS

## Overview

This PR addresses two critical issues in the Soroban Identity protocol:
1. **#401**: Inability to reactivate accidentally deactivated DIDs without admin intervention
2. **#402**: Unbounded issuer credentials index leading to potential DoS via storage exhaustion

## Issues Addressed

Closes #401
Closes #402

## Changes

### Issue #401: DID Reactivation Endpoint

**Problem**: After calling `deactivate_did`, the on-chain record remains (soft-delete) but `create_did` returns `DidAlreadyExists` because the key still exists in persistent storage. There was no way to re-register after accidental deactivation without admin intervention.

**Solution**: Added `reactivate_did(admin, controller)` entry point to the identity-registry contract with the following features:

#### Implementation Details (identity-registry/src/lib.rs)
- **Authorization**: Only the admin can call this function; the controller cannot self-reactivate to prevent abuse
- **Idempotent**: Calling on an already-active DID is a no-op and returns `Ok(())`
- **State Update**: Sets `active=true` and updates `updated_at` timestamp on the existing document
- **Event Emission**: Emits `IDENTITY/reactivated` event with event version, controller, and updated timestamp
- **Counter Increment**: Increments the active DID count to reflect the restored DID

#### Acceptance Criteria Met
- ✅ `reactivate_did` called by non-admin returns `Unauthorized`
- ✅ `reactivate_did` on an already-active DID is a no-op and returns `Ok()`
- ✅ Emits `IDENTITY/reactivated` event; active DID count is restored

#### Tests Added
- `test_reactivate_did_unauthorized_non_admin`: Validates authorization checks
- `test_reactivate_did_already_active_is_noop`: Confirms idempotent behavior
- `test_reactivate_did_restores_active_did`: Verifies full restoration workflow with count increment

---

### Issue #402: Cap Issuer Credentials Index via Ring-Buffer

**Problem**: The `ISSUER_CREDS` secondary index stores every credential ID an issuer has ever issued in a Vec with no upper bound. A single issuer issuing millions of credentials can inflate the index entry past Soroban's per-entry storage limit (512KB), causing all subsequent reads for that issuer to fail with storage exhaustion errors.

**Solution**: Implemented ring-buffer semantics with a configurable cap on the per-issuer credential index.

#### Implementation Details (credential-manager/src/lib.rs)
- **Constant**: Added `MAX_ISSUER_CREDS = 10_000` to cap per-issuer index size
- **Ring-Buffer Logic**: When the cap is reached during `issue_credential`:
  - Drop the oldest entry from the head of the Vec
  - Add the new credential ID to the tail
  - Maintains exactly `MAX_ISSUER_CREDS` entries after the cap is hit
- **Error Handling**: Issuing the (MAX_ISSUER_CREDS + 1)th credential does not panic or error; operation completes successfully
- **Storage**: Index length stays at `MAX_ISSUER_CREDS` after the cap is initially hit

#### Acceptance Criteria Met
- ✅ Issuing the (MAX_ISSUER_CREDS + 1)th credential does not panic or error
- ✅ The index length stays at MAX_ISSUER_CREDS after the cap is hit
- ✅ New test verifies ring-buffer eviction behavior

#### Tests Added
- `test_issuer_credentials_ring_buffer_eviction`: Issues 10,001 credentials from different subjects, verifies:
  - Index stays at MAX_ISSUER_CREDS after cap is hit
  - The first (oldest) credential ID is evicted from the index
  - Subsequent issuances continue without errors

---

## Technical Details

### Files Modified
- `contracts/identity-registry/src/lib.rs` (+130 lines)
  - New `reactivate_did()` function with full documentation
  - Three comprehensive test cases
  
- `contracts/credential-manager/src/lib.rs` (+49 lines)
  - New `MAX_ISSUER_CREDS` constant
  - Ring-buffer eviction logic in `issue_credential()` 
  - One comprehensive test case

### Key Design Decisions

1. **DID Reactivation**: Restricted to admin-only to prevent abuse while allowing legitimate recovery from accidental deactivation. No-op on already-active DIDs ensures idempotency.

2. **Ring-Buffer Strategy**: Uses `Vec::slice()` to drop the head and `push_back()` to append, maintaining FIFO semantics. The cap of 10,000 provides a reasonable limit that prevents storage exhaustion while allowing practical issuer operation (e.g., 10K credentials from an issuer fits well within Soroban's 512KB entry limit even with metadata).

3. **Backward Compatibility**: Both changes are purely additive (new function, new logic branch). Existing contracts and queries are unaffected.

---

## Testing

All changes include comprehensive unit tests:

### Identity Registry Tests
- Authorization enforcement for `reactivate_did`
- Idempotent behavior verification
- State restoration and counter increment validation

### Credential Manager Tests
- Ring-buffer eviction under load (10K+ credentials)
- Index size maintenance verification
- Oldest-entry eviction confirmation

Run tests with:
bash
cd contracts && cargo test --lib

---

## Impact

### Security
- **#401**: Improves operational resilience by enabling legitimate DID recovery
- **#402**: Prevents DoS attacks via unbounded index growth that could exhaust per-entry storage limits

### Performance
- **#401**: O(1) reactivation operation
- **#402**: O(n) ring-buffer eviction during cap breach is negligible (10K cap, amortized constant per issuance)

### Compatibility
- Non-breaking; all changes are additive
- Existing DID and credential workflows unaffected
- Event schemas unchanged (new `reactivated` event topic follows existing convention)

---

## Deployment Notes

1. No contract upgrades required for existing deployments; both features activate on next deployment
2. Monitor `get_did_count()` after reactivations to track administrative recovery actions
3. For issuers nearing 10K credential issuances, monitor `list_issuer_credentials()` pagination to ensure application assumes ring-buffer semantics
4. TTL extension maintained on both reactivated DIDs and capped issuer indices

---

## Related Issues

- Resolves #401
- Resolves #402
- Complements existing DID lifecycle (create, update, deactivate)
- Complements existing credential management (issue, verify, revoke)

