### PR TITLE
fix(#328, #327): ReputationChart empty-state ARIA + upsertCredential mutation

### DIFF
--- a/frontend/src/components/ReputationChart.test.tsx
+++ b/frontend/src/components/ReputationChart.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import ReputationChart from "./ReputationChart";
+import type { ScoreHistoryEntry } from "../../../sdk/src/reputation";
+
+const sampleHistory: ScoreHistoryEntry[] = [
+  { reporter: "GREPORTER1", submittedAt: 1700000000, delta: 10, reason: "activity" },
+  { reporter: "GREPORTER1", submittedAt: 1700086400, delta: -5, reason: "penalty" },
+];
+
+describe("ReputationChart", () => {
+  it("renders empty-state when history is empty", () => {
+    const { container } = render(<ReputationChart history={[]} />);
+    const p = container.querySelector("p");
+    expect(p).not.toBeNull();
+    expect(p!.textContent).toBe("No reputation history yet.");
+    expect(p!.getAttribute("role")).toBe("status");
+  });
+
+  it("does not render empty-state when history is non-empty", () => {
+    const { container } = render(<ReputationChart history={sampleHistory} />);
+    const p = container.querySelector("p[role='status']");
+    expect(p).toBeNull();
+  });
+
+  it("renders chart container when history is non-empty", () => {
+    const { container } = render(<ReputationChart history={sampleHistory} />);
+    // recharts renders an svg
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+  });
+
+  it("matches empty-state snapshot", () => {
+    const { container } = render(<ReputationChart history={[]} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("matches non-empty chart snapshot", () => {
+    const { container } = render(<ReputationChart history={sampleHistory} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/ReputationChart.tsx
+++ b/frontend/src/components/ReputationChart.tsx
@@ -62,8 +62,8 @@ export default function ReputationChart({ history }: Props) {
 
   if (history.length === 0) {
     return (
-      <p style={{ color: "var(--text-muted)", fontSize: "0.85rem", textAlign: "center", padding: "1rem 0" }}>
-        No score history available.
+      <p role="status" style={{ color: "var(--text-muted)", fontSize: "0.85rem", textAlign: "center", padding: "1rem 0" }}>
+        No reputation history yet.
       </p>
     );
   }

--- a/server/src/storage.js
+++ b/server/src/storage.js
@@ -103,7 +103,7 @@ export async function writeCredentials(config, credentials) {
 export function upsertCredential(credentials, credential) {
   const index = credentials.findIndex((item) => item.id === credential.id);
   if (index === -1) return [...credentials, credential];
-  const next = credentials.slice();
+  const next = credentials.map((c) => ({ ...c }));
   next[index] = { ...next[index], ...credential };
   return next;
 }

--- a/server/test/storage.test.js
+++ b/server/test/storage.test.js
@@ -3,7 +3,7 @@ import test from 'node:test';
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
-import { appendAuditLog, ensureDataDir } from '../src/storage.js';
+import { appendAuditLog, ensureDataDir, upsertCredential } from '../src/storage.js';
 
 // Simple date mock
 const OriginalDate = global.Date;
@@ -97,4 +97,40 @@ test('ensureDataDir deletes audit files older than retention days', async () => 
   assert.ok(fs.existsSync(pathActiveLimit), 'File at exact limit age should NOT be deleted');
   assert.ok(!fs.existsSync(pathExpired), 'Expired file should be deleted');
   assert.ok(!fs.existsSync(pathExpiredOlder), 'Very old expired file should be deleted');
+});
+
+test('upsertCredential inserts a new credential when id is not found', () => {
+  const original = [{ id: 'a', status: 'active' }];
+  const result = upsertCredential(original, { id: 'b', status: 'pending' });
+  assert.equal(result.length, 2);
+  assert.deepEqual(result[1], { id: 'b', status: 'pending' });
+});
+
+test('upsertCredential does not mutate the original array on update', () => {
+  const cred = { id: 'a', status: 'active', extra: 'original' };
+  const original = [cred];
+  const result = upsertCredential(original, { id: 'a', status: 'revoked' });
+
+  // Original array and object must be unchanged
+  assert.equal(original[0].status, 'active');
+  assert.equal(original.length, 1);
+
+  // Result must reflect the update
+  assert.equal(result[0].status, 'revoked');
+  assert.equal(result[0].extra, 'original');
+});
+
+test('upsertCredential returns a distinct object reference for updated entry', () => {
+  const original = [{ id: 'a', status: 'active' }];
+  const result = upsertCredential(original, { id: 'a', status: 'revoked' });
+  assert.notEqual(result[0], original[0]);
+});
+
+test('upsertCredential non-updated entries are also distinct references', () => {
+  const original = [{ id: 'a', v: 1 }, { id: 'b', v: 2 }];
+  const result = upsertCredential(original, { id: 'a', v: 99 });
+  // The bystander entry at index 1 must not be the same object reference
+  assert.notEqual(result[1], original[1]);
+  // But its data is preserved
+  assert.deepEqual(result[1], original[1]);
 });


### PR DESCRIPTION
## Summary

Fixes #328 and #327.

### #328 — ReputationChart NaN axis labels on empty history

The component already had an empty-state guard but used incorrect text and lacked an ARIA role.

**Changes:**
- `ReputationChart.tsx`: updated empty-state text to `No reputation history yet.` and added `role="status"` for accessibility.

### #327 — upsertCredential mutates input credentials array

`credentials.slice()` copies the array but keeps the same object references. Mutating `next[index]` via spread still leaves other entries sharing references with the original.

**Changes:**
- `storage.js`: replaced `credentials.slice()` with `credentials.map(c => ({ ...c }))` so every entry in `next` is a new object — no input reference is shared.

## Tests

- `ReputationChart.test.tsx`: empty-state render (text + ARIA role), no empty-state on non-empty history, chart SVG present, two snapshots.
- `storage.test.js`: insert path, no array mutation on update, distinct reference for updated entry, distinct reference for bystander entries. All 6 storage tests pass.

## Checklist
- [x] Bug fix (non-breaking)
- [x] Tests added / updated
- [x] No new dependencies introduced
Closes #327 
Closes #328 