### PR TITLE
test: add cross_contract_lifecycle integration test closes #400

### DIFF
--- a/contracts/tests/lifecycle.rs
+++ b/contracts/tests/lifecycle.rs
@@ -113,3 +113,69 @@ fn contracts_expose_ping_version() {
     assert_eq!(credentials.ping(), 1);
     assert_eq!(reputation.ping(), 1);
 }
+
+/// End-to-end cross-contract lifecycle test (#400):
+/// Deploys all three contracts in one Env, registers a DID, issues a credential
+/// for that DID, submits a reputation score, and asserts final state across all
+/// three contracts is consistent.
+#[test]
+fn cross_contract_lifecycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let identity_id = env.register_contract(None, IdentityRegistry);
+    let credential_id = env.register_contract(None, CredentialManager);
+    let reputation_id = env.register_contract(None, Reputation);
+
+    let identity = IdentityRegistryClient::new(&env, &identity_id);
+    let credentials = CredentialManagerClient::new(&env, &credential_id);
+    let reputation = ReputationClient::new(&env, &reputation_id);
+
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let reporter = Address::generate(&env);
+    let subject = Address::generate(&env);
+
+    // Initialize all three contracts
+    identity.initialize(&admin);
+    credentials.initialize(&admin, &identity_id);
+    reputation.initialize(&admin);
+
+    // 1. Register DID in identity-registry
+    let did = identity.create_did(&subject, &Map::new(&env));
+    assert!(identity.has_active_did(&subject));
+    let doc = identity.resolve_did(&subject);
+    assert!(doc.active);
+    assert_eq!(doc.controller, subject);
+    let mut did_bytes = [0u8; 68];
+    did.copy_into_slice(&mut did_bytes);
+    assert_eq!(&did_bytes[..12], b"did:stellar:");
+
+    // 2. Issue a credential for that DID subject in credential-manager
+    credentials.add_issuer(&issuer);
+    let cred_id = credentials.issue_credential(
+        &issuer,
+        &subject,
+        &CredentialType::Kyc,
+        &Map::new(&env),
+        &BytesN::from_array(&env, &[0u8; 32]),
+        &Bytes::from_array(&env, &[1u8; 64]),
+        &0u64,
+    );
+    assert!(credentials.verify_credential(&cred_id));
+    let cred = credentials.get_credential(&cred_id);
+    assert_eq!(cred.subject, subject);
+
+    // 3. Submit a reputation score for the same subject in reputation
+    reputation.add_reporter(&reporter);
+    let reason = String::from_str(&env, "kyc verified");
+    reputation.submit_score(&reporter, &subject, &60, &reason);
+
+    // Assert final state across all three contracts is consistent
+    assert!(identity.has_active_did(&subject));          // DID still active
+    assert!(credentials.verify_credential(&cred_id));    // credential still valid
+    let rec = reputation.get_reputation(&subject);
+    assert!(rec.score > 0);                              // reputation score is non-zero
+    assert_eq!(rec.reporter_count, 1);
+    assert!(reputation.passes_sybil_check(&subject, &50, &1));
+}


### PR DESCRIPTION
Closes #400

## Summary

This PR adds an end-to-end integration test covering the complete identity lifecycle across the Identity Registry, Credential Manager, and Reputation contracts, validating that the contracts interoperate correctly in a shared Soroban environment.

## Motivation

While each contract has unit tests, there was no integration test verifying cross-contract behaviour. This test ensures the complete identity workflow functions as expected.

## Type of change

* [x] `test` — tests only

## Changes

* Added `cross_contract_lifecycle` integration test.
* Deploys all three contracts into a shared `Env`.
* Registers a DID.
* Issues a credential for the DID.
* Submits a reputation score.
* Verifies:

  * DID is active.
  * Credential is verifiable.
  * Reputation score is greater than zero.
* Ensures contracts interoperate correctly throughout the lifecycle.

## Testing

Verified:

* All contracts deploy successfully in a shared environment.
* DID registration succeeds.
* Credential issuance succeeds.
* Reputation score submission succeeds.
* Final assertions confirm expected cross-contract state.

## Checklist

* [x] `cargo fmt` run
* [x] `cargo clippy -- -D warnings` passes
* [x] Integration tests added
* [x] CI is green
* [ ] Documentation update not required
* [x] No secrets committed
