### PR TITLE
feat(#337): display skeleton loader while reputation score history is loading

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@creit.tech/stellar-wallets-kit": "^0.9.5",
+    "@creit.tech/stellar-wallets-kit": "^0.9.2",
     "@soroban-identity/sdk": "^0.1.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "@walletconnect/sign-client": "^2.17.0",
@@ -21,12 +21,14 @@
     "recharts": "^3.8.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
     "@types/node": "^20.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^29.1.1",
     "typescript": "^5.4.0",
     "vite": "^5.2.0",
     "vitest": "^1.5.0"

--- a/frontend/src/components/ReputationChart.test.tsx
+++ b/frontend/src/components/ReputationChart.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import ReputationChart from "./ReputationChart";
+import type { ScoreHistoryEntry } from "../../../sdk/src/reputation";
+
+const mockHistory: ScoreHistoryEntry[] = [
+  {
+    score: 10,
+    delta: 5,
+    reason: "Contribution",
+    submittedBy: "GBXXX...",
+    submittedAt: Math.floor(Date.now() / 1000) - 86400,
+  },
+  {
+    score: 15,
+    delta: 5,
+    reason: "Verification",
+    submittedBy: "GBXXX...",
+    submittedAt: Math.floor(Date.now() / 1000),
+  },
+];
+
+// Recharts ResponsiveContainer often needs fallback or resize observer in jsdom
+vi.mock("recharts", async (importOriginal) => {
+  const original = await importOriginal<typeof import("recharts")>();
+  return {
+    ...original,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="responsive-container" style={{ width: "100%", height: 200 }}>
+        {children}
+      </div>
+    ),
+  };
+});
+
+describe("ReputationChart", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders skeleton placeholder during loading state with correct aria-label and dimensions", () => {
+    const { container } = render(<ReputationChart history={[]} isLoading={true} />);
+
+    const skeleton = screen.getByLabelText("Loading reputation chart");
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveClass("card", "skeleton-card");
+
+    // Check style has height 200 applied
+    expect(skeleton.style.height).toBe("200px");
+    expect(container.querySelector(".skeleton-title")).toBeInTheDocument();
+  });
+
+  it("shows skeleton loader when isLoading=true even if history is empty", () => {
+    render(<ReputationChart history={[]} isLoading={true} />);
+    expect(screen.getByLabelText("Loading reputation chart")).toBeInTheDocument();
+    expect(screen.queryByText("No score history available.")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when isLoading=false and history is empty", () => {
+    render(<ReputationChart history={[]} isLoading={false} />);
+    expect(screen.getByText("No score history available.")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Loading reputation chart")).not.toBeInTheDocument();
+  });
+
+  it("renders chart when isLoading=false and history has items", () => {
+    render(<ReputationChart history={mockHistory} isLoading={false} />);
+    expect(screen.queryByLabelText("Loading reputation chart")).not.toBeInTheDocument();
+    expect(screen.getByTestId("responsive-container")).toBeInTheDocument();
+  });
+
+  it("matches snapshot when loading", () => {
+    const { container } = render(<ReputationChart history={[]} isLoading={true} />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/ReputationChart.tsx
+++ b/frontend/src/components/ReputationChart.tsx
@@ -10,10 +10,14 @@ import {
   Cell,
 } from "recharts";
 import type { ScoreHistoryEntry } from "../../../sdk/src/reputation";
+import SkeletonCard from "./SkeletonCard";
 
 interface Props {
   history: ScoreHistoryEntry[];
+  isLoading?: boolean;
 }
+
+const CHART_HEIGHT = 200;
 
 function formatTimestamp(ts: number): string {
   return new Date(ts * 1000).toLocaleDateString(undefined, { month: "short", day: "numeric" });
@@ -26,7 +30,7 @@ function formatDateForInput(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-export default function ReputationChart({ history }: Props) {
+export default function ReputationChart({ history, isLoading = false }: Props) {
   const [startDate, setStartDate] = useState<string>(() => {
     const end = new Date();
     const start = new Date(end.getTime() - 30 * 24 * 60 * 60 * 1000);
@@ -59,6 +63,10 @@ export default function ReputationChart({ history }: Props) {
     setEndDate(formatDateForInput(end));
     setValidationError(null);
   };
+
+  if (isLoading) {
+    return <SkeletonCard height={CHART_HEIGHT} aria-label="Loading reputation chart" />;
+  }
 
   if (history.length === 0) {
     return (
@@ -126,7 +134,7 @@ export default function ReputationChart({ history }: Props) {
         </div>
       )}
 
-      <div style={{ width: "100%", height: 200 }}>
+      <div style={{ width: "100%", height: CHART_HEIGHT }}>
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={filteredHistory} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="var(--border-input)" />

--- a/frontend/src/components/SkeletonCard.tsx
+++ b/frontend/src/components/SkeletonCard.tsx
@@ -1,13 +1,24 @@
+import type { CSSProperties } from 'react';
+
 export type SkeletonVariant = 'credential' | 'identity' | 'reputation';
 
 interface Props {
   rows?: number;
   variant?: SkeletonVariant;
+  height?: number | string;
+  width?: number | string;
+  'aria-label'?: string;
+  style?: CSSProperties;
 }
 
-function CredentialSkeleton() {
+interface SkeletonProps {
+  style?: CSSProperties;
+  ariaLabel?: string;
+}
+
+function CredentialSkeleton({ style, ariaLabel }: SkeletonProps) {
   return (
-    <div className="card skeleton-card" aria-busy="true" aria-label="Loading…">
+    <div className="card skeleton-card" aria-busy="true" aria-label={ariaLabel ?? "Loading…"} style={style}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
         <div className="skeleton" style={{ width: '2rem', height: '2rem', borderRadius: '0.25rem', flexShrink: 0 }} />
         <div className="skeleton skeleton-title" style={{ flex: 1 }} />
@@ -20,9 +31,9 @@ function CredentialSkeleton() {
   );
 }
 
-function IdentitySkeleton() {
+function IdentitySkeleton({ style, ariaLabel }: SkeletonProps) {
   return (
-    <div className="card skeleton-card" aria-busy="true" aria-label="Loading…">
+    <div className="card skeleton-card" aria-busy="true" aria-label={ariaLabel ?? "Loading…"} style={style}>
       <div className="skeleton skeleton-title" style={{ width: '60%', marginBottom: '0.75rem' }} />
       <div className="skeleton skeleton-row" style={{ width: '100%' }} />
       <div className="skeleton skeleton-row" style={{ width: '100%' }} />
@@ -33,9 +44,9 @@ function IdentitySkeleton() {
   );
 }
 
-function ReputationSkeleton() {
+function ReputationSkeleton({ style, ariaLabel }: SkeletonProps) {
   return (
-    <div className="card skeleton-card" aria-busy="true" aria-label="Loading…">
+    <div className="card skeleton-card" aria-busy="true" aria-label={ariaLabel ?? "Loading…"} style={style}>
       <div className="skeleton skeleton-title" style={{ width: '40%', marginBottom: '0.75rem' }} />
       <div style={{ display: 'flex', gap: '1rem', marginBottom: '0.5rem' }}>
         <div className="skeleton" style={{ width: '3rem', height: '3rem', borderRadius: '50%' }} />
@@ -49,13 +60,26 @@ function ReputationSkeleton() {
   );
 }
 
-export default function SkeletonCard({ rows = 3, variant }: Props) {
-  if (variant === 'credential') return <CredentialSkeleton />;
-  if (variant === 'identity') return <IdentitySkeleton />;
-  if (variant === 'reputation') return <ReputationSkeleton />;
+export default function SkeletonCard({
+  rows = 3,
+  variant,
+  height,
+  width,
+  'aria-label': ariaLabel,
+  style,
+}: Props) {
+  const containerStyle: CSSProperties = {
+    ...style,
+    ...(height !== undefined ? { height } : {}),
+    ...(width !== undefined ? { width } : {}),
+  };
+
+  if (variant === 'credential') return <CredentialSkeleton style={containerStyle} ariaLabel={ariaLabel} />;
+  if (variant === 'identity') return <IdentitySkeleton style={containerStyle} ariaLabel={ariaLabel} />;
+  if (variant === 'reputation') return <ReputationSkeleton style={containerStyle} ariaLabel={ariaLabel} />;
 
   return (
-    <div className="card skeleton-card" aria-busy="true" aria-label="Loading…">
+    <div className="card skeleton-card" aria-busy="true" aria-label={ariaLabel ?? "Loading…"} style={containerStyle}>
       <div className="skeleton skeleton-title" />
       {Array.from({ length: rows }).map((_, i) => (
         <div key={i} className="skeleton skeleton-row" style={{ width: i === rows - 1 ? "60%" : "100%" }} />

--- a/frontend/src/components/__snapshots__/ReputationChart.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/ReputationChart.test.tsx.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ReputationChart > matches snapshot when loading 1`] = `
+<div>
+  <div
+    aria-busy="true"
+    aria-label="Loading reputation chart"
+    class="card skeleton-card"
+    style="height: 200px;"
+  >
+    <div
+      class="skeleton skeleton-title"
+    />
+    <div
+      class="skeleton skeleton-row"
+      style="width: 100%;"
+    />
+    <div
+      class="skeleton skeleton-row"
+      style="width: 100%;"
+    />
+    <div
+      class="skeleton skeleton-row"
+      style="width: 60%;"
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Summary
Resolves #337

Closes #337 

### Changes Made
- Updated \SkeletonCard\ to accept optional \height\, \width\, \ria-label\, and \style\ properties and apply them to the outer container.
- Added optional \isLoading: boolean\ property to \ReputationChart\.
- When \isLoading\ is true, \ReputationChart\ renders a \SkeletonCard\ matching the height of the chart (\200px\) with \ria-label='Loading reputation chart'\, eliminating Cumulative Layout Shift (CLS).
- Ensured passing \isLoading={false}\ with an empty history shows the empty state message without rendering the skeleton.
- Created unit tests and snapshot tests covering loading state, empty state, and loaded chart state.